### PR TITLE
Updated NvEnc API to version 12.2

### DIFF
--- a/src/NvEncSharp.Sample.ScreenCapture/Program.cs
+++ b/src/NvEncSharp.Sample.ScreenCapture/Program.cs
@@ -164,7 +164,7 @@ namespace Lennox.NvEncSharp.Sample.ScreenCapture
 
             var desc = texture.Description;
             var encoder = OpenEncoderForDirectX(texture.Device.NativePointer);
-            var encoderConfig = encoder.GetEncodePresetConfig(NvEncCodecGuids.H264, NvEncPresetGuids.LowLatencyDefault).PresetCfg;
+            var encoderConfig = encoder.GetEncodePresetConfigEx(NvEncCodecGuids.H264, NvEncPresetGuids.P1).PresetCfg;
             encoderConfig.RcParams.AverageBitRate = 4 * (1 << 20); // 4 Mbit
             encoderConfig.RcParams.MaxBitRate = 8 * (1 << 20);
             encoderConfig.RcParams.RateControlMode = NvEncParamsRcMode.Vbr;
@@ -186,11 +186,12 @@ namespace Lennox.NvEncSharp.Sample.ScreenCapture
                     FrameRateDen = 1,
                     ReportSliceOffsets = false,
                     EnableSubFrameWrite = false,
-                    PresetGuid = NvEncPresetGuids.LowLatencyDefault,
+                    PresetGuid = NvEncPresetGuids.P1,
                     EnableEncodeAsync = 0,
                     EnablePTD = 1,
                     EnableWeightedPrediction = true,
                     EncodeConfig = p,
+                    TuningInfo = NvEncTuningInfo.HighQuality,
                 };
 
                 encoder.InitializeEncoder(ref initparams);

--- a/src/NvEncSharp.Test/nvEncodeAPI.h
+++ b/src/NvEncSharp.Test/nvEncodeAPI.h
@@ -1,7 +1,7 @@
 /*
  * This copyright notice applies to this header file only:
  *
- * Copyright (c) 2010-2019 NVIDIA Corporation
+ * Copyright (c) 2010-2024 NVIDIA Corporation
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -30,7 +30,7 @@
  *   NVIDIA GPUs - beginning with the Kepler generation - contain a hardware-based encoder
  *   (referred to as NVENC) which provides fully-accelerated hardware-based video encoding.
  *   NvEncodeAPI provides the interface for NVIDIA video encoder (NVENC).
- * \date 2011-2019
+ * \date 2011-2024
  *  This file contains the interface constants, structure definitions and function prototypes.
  */
 
@@ -73,20 +73,21 @@ typedef RECT NVENC_RECT;
 #else
 #define NVENCAPI
 // =========================================================================================
-#ifndef GUID
+#ifndef GUID_DEFINED
+#define GUID_DEFINED
 /*!
  * \struct GUID
  * Abstracts the GUID structure for non-windows platforms.
  */
 // =========================================================================================
-typedef struct
+typedef struct _GUID
 {
     uint32_t Data1;                                      /**< [in]: Specifies the first 8 hexadecimal digits of the GUID.                                */
     uint16_t Data2;                                      /**< [in]: Specifies the first group of 4 hexadecimal digits.                                   */
     uint16_t Data3;                                      /**< [in]: Specifies the second group of 4 hexadecimal digits.                                  */
     uint8_t  Data4[8];                                   /**< [in]: Array of 8 bytes. The first 2 bytes contain the third group of 4 hexadecimal digits.
                                                                     The remaining 6 bytes contain the final 12 hexadecimal digits.                       */
-} GUID;
+} GUID, *LPGUID;
 #endif // GUID
 
 /**
@@ -110,8 +111,8 @@ typedef void* NV_ENC_OUTPUT_PTR;            /**< NVENCODE API output buffer*/
 typedef void* NV_ENC_REGISTERED_PTR;        /**< A Resource that has been registered with NVENCODE API*/
 typedef void* NV_ENC_CUSTREAM_PTR;          /**< Pointer to CUstream*/
 
-#define NVENCAPI_MAJOR_VERSION 9
-#define NVENCAPI_MINOR_VERSION 1
+#define NVENCAPI_MAJOR_VERSION 12
+#define NVENCAPI_MINOR_VERSION 2
 
 #define NVENCAPI_VERSION (NVENCAPI_MAJOR_VERSION | (NVENCAPI_MINOR_VERSION << 24))
 
@@ -125,6 +126,12 @@ typedef void* NV_ENC_CUSTREAM_PTR;          /**< Pointer to CUstream*/
 
 #define NV_MAX_SEQ_HDR_LEN  (512)
 
+#ifdef __GNUC__
+#define NV_ENC_DEPRECATED __attribute__ ((deprecated("WILL BE REMOVED IN A FUTURE VIDEO CODEC SDK VERSION")))
+#elif defined(_MSC_VER)
+#define NV_ENC_DEPRECATED __declspec(deprecated("WILL BE REMOVED IN A FUTURE VIDEO CODEC SDK VERSION"))
+#endif
+
 // =========================================================================================
 // Encode Codec GUIDS supported by the NvEncodeAPI interface.
 // =========================================================================================
@@ -136,6 +143,10 @@ static const GUID NV_ENC_CODEC_H264_GUID =
 // {790CDC88-4522-4d7b-9425-BDA9975F7603}
 static const GUID NV_ENC_CODEC_HEVC_GUID =
 { 0x790cdc88, 0x4522, 0x4d7b, { 0x94, 0x25, 0xbd, 0xa9, 0x97, 0x5f, 0x76, 0x3 } };
+
+// {0A352289-0AA7-4759-862D-5D15CD16D254}
+static const GUID NV_ENC_CODEC_AV1_GUID =
+{ 0x0a352289, 0x0aa7, 0x4759, { 0x86, 0x2d, 0x5d, 0x15, 0xcd, 0x16, 0xd2, 0x54 } };
 
 
 
@@ -167,10 +178,6 @@ static const GUID  NV_ENC_H264_PROFILE_HIGH_444_GUID =
 static const GUID NV_ENC_H264_PROFILE_STEREO_GUID =
 { 0x40847bf5, 0x33f7, 0x4601, { 0x90, 0x84, 0xe8, 0xfe, 0x3c, 0x1d, 0xb8, 0xb7 } };
 
-// {CE788D20-AAA9-4318-92BB-AC7E858C8D36}
-static const GUID NV_ENC_H264_PROFILE_SVC_TEMPORAL_SCALABILTY =
-{ 0xce788d20, 0xaaa9, 0x4318, { 0x92, 0xbb, 0xac, 0x7e, 0x85, 0x8c, 0x8d, 0x36 } };
-
 // {B405AFAC-F32B-417B-89C4-9ABEED3E5978}
 static const GUID NV_ENC_H264_PROFILE_PROGRESSIVE_HIGH_GUID =
 { 0xb405afac, 0xf32b, 0x417b, { 0x89, 0xc4, 0x9a, 0xbe, 0xed, 0x3e, 0x59, 0x78 } };
@@ -192,44 +199,44 @@ static const GUID NV_ENC_HEVC_PROFILE_MAIN10_GUID =
 static const GUID NV_ENC_HEVC_PROFILE_FREXT_GUID =
 { 0x51ec32b5, 0x1b4c, 0x453c, { 0x9c, 0xbd, 0xb6, 0x16, 0xbd, 0x62, 0x13, 0x41 } };
 
+// {5f2a39f5-f14e-4f95-9a9e-b76d568fcf97}
+static const GUID NV_ENC_AV1_PROFILE_MAIN_GUID =
+{ 0x5f2a39f5, 0xf14e, 0x4f95, { 0x9a, 0x9e, 0xb7, 0x6d, 0x56, 0x8f, 0xcf, 0x97 } };
+
 // =========================================================================================
 // *   Preset GUIDS supported by the NvEncodeAPI interface.
 // =========================================================================================
-// {B2DFB705-4EBD-4C49-9B5F-24A777D3E587}
-static const GUID NV_ENC_PRESET_DEFAULT_GUID =
-{ 0xb2dfb705, 0x4ebd, 0x4c49, { 0x9b, 0x5f, 0x24, 0xa7, 0x77, 0xd3, 0xe5, 0x87 } };
 
-// {60E4C59F-E846-4484-A56D-CD45BE9FDDF6}
-static const GUID NV_ENC_PRESET_HP_GUID =
-{ 0x60e4c59f, 0xe846, 0x4484, { 0xa5, 0x6d, 0xcd, 0x45, 0xbe, 0x9f, 0xdd, 0xf6 } };
+// Performance degrades and quality improves as we move from P1 to P7. Presets P3 to P7 for H264 and Presets P2 to P7 for HEVC have B frames enabled by default
+// for HIGH_QUALITY and LOSSLESS tuning info, and will not work with Weighted Prediction enabled. In case Weighted Prediction is required, disable B frames by
+// setting frameIntervalP = 1
+// {FC0A8D3E-45F8-4CF8-80C7-298871590EBF}
+static const GUID NV_ENC_PRESET_P1_GUID   =
+{ 0xfc0a8d3e, 0x45f8, 0x4cf8, { 0x80, 0xc7, 0x29, 0x88, 0x71, 0x59, 0xe, 0xbf } };
 
-// {34DBA71D-A77B-4B8F-9C3E-B6D5DA24C012}
-static const GUID NV_ENC_PRESET_HQ_GUID =
-{ 0x34dba71d, 0xa77b, 0x4b8f, { 0x9c, 0x3e, 0xb6, 0xd5, 0xda, 0x24, 0xc0, 0x12 } };
+// {F581CFB8-88D6-4381-93F0-DF13F9C27DAB}
+static const GUID NV_ENC_PRESET_P2_GUID   =
+{ 0xf581cfb8, 0x88d6, 0x4381, { 0x93, 0xf0, 0xdf, 0x13, 0xf9, 0xc2, 0x7d, 0xab } };
 
-// {82E3E450-BDBB-4e40-989C-82A90DF9EF32}
-static const GUID NV_ENC_PRESET_BD_GUID  =
-{ 0x82e3e450, 0xbdbb, 0x4e40, { 0x98, 0x9c, 0x82, 0xa9, 0xd, 0xf9, 0xef, 0x32 } };
+// {36850110-3A07-441F-94D5-3670631F91F6}
+static const GUID NV_ENC_PRESET_P3_GUID   =
+{ 0x36850110, 0x3a07, 0x441f, { 0x94, 0xd5, 0x36, 0x70, 0x63, 0x1f, 0x91, 0xf6 } };
 
-// {49DF21C5-6DFA-4feb-9787-6ACC9EFFB726}
-static const GUID NV_ENC_PRESET_LOW_LATENCY_DEFAULT_GUID  =
-{ 0x49df21c5, 0x6dfa, 0x4feb, { 0x97, 0x87, 0x6a, 0xcc, 0x9e, 0xff, 0xb7, 0x26 } };
+// {90A7B826-DF06-4862-B9D2-CD6D73A08681}
+static const GUID NV_ENC_PRESET_P4_GUID   =
+{ 0x90a7b826, 0xdf06, 0x4862, { 0xb9, 0xd2, 0xcd, 0x6d, 0x73, 0xa0, 0x86, 0x81 } };
 
-// {C5F733B9-EA97-4cf9-BEC2-BF78A74FD105}
-static const GUID NV_ENC_PRESET_LOW_LATENCY_HQ_GUID  =
-{ 0xc5f733b9, 0xea97, 0x4cf9, { 0xbe, 0xc2, 0xbf, 0x78, 0xa7, 0x4f, 0xd1, 0x5 } };
+// {21C6E6B4-297A-4CBA-998F-B6CBDE72ADE3}
+static const GUID NV_ENC_PRESET_P5_GUID   =
+{ 0x21c6e6b4, 0x297a, 0x4cba, { 0x99, 0x8f, 0xb6, 0xcb, 0xde, 0x72, 0xad, 0xe3 } };
 
-// {67082A44-4BAD-48FA-98EA-93056D150A58}
-static const GUID NV_ENC_PRESET_LOW_LATENCY_HP_GUID =
-{ 0x67082a44, 0x4bad, 0x48fa, { 0x98, 0xea, 0x93, 0x5, 0x6d, 0x15, 0xa, 0x58 } };
+// {8E75C279-6299-4AB6-8302-0B215A335CF5}
+static const GUID NV_ENC_PRESET_P6_GUID   =
+{ 0x8e75c279, 0x6299, 0x4ab6, { 0x83, 0x2, 0xb, 0x21, 0x5a, 0x33, 0x5c, 0xf5 } };
 
-// {D5BFB716-C604-44e7-9BB8-DEA5510FC3AC}
-static const GUID NV_ENC_PRESET_LOSSLESS_DEFAULT_GUID =
-{ 0xd5bfb716, 0xc604, 0x44e7, { 0x9b, 0xb8, 0xde, 0xa5, 0x51, 0xf, 0xc3, 0xac } };
-
-// {149998E7-2364-411d-82EF-179888093409}
-static const GUID NV_ENC_PRESET_LOSSLESS_HP_GUID =
-{ 0x149998e7, 0x2364, 0x411d, { 0x82, 0xef, 0x17, 0x98, 0x88, 0x9, 0x34, 0x9 } };
+// {84848C12-6F71-4C13-931B-53E283F57974}
+static const GUID NV_ENC_PRESET_P7_GUID   =
+{ 0x84848c12, 0x6f71, 0x4c13, { 0x93, 0x1b, 0x53, 0xe2, 0x83, 0xf5, 0x79, 0x74 } };
 
 /**
  * \addtogroup ENCODER_STRUCTURE NvEncodeAPI Data structures
@@ -254,10 +261,33 @@ typedef enum _NV_ENC_PARAMS_RC_MODE
     NV_ENC_PARAMS_RC_CONSTQP                = 0x0,       /**< Constant QP mode */
     NV_ENC_PARAMS_RC_VBR                    = 0x1,       /**< Variable bitrate mode */
     NV_ENC_PARAMS_RC_CBR                    = 0x2,       /**< Constant bitrate mode */
-    NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ        = 0x8,       /**< low-delay CBR, high quality */
-    NV_ENC_PARAMS_RC_CBR_HQ                 = 0x10,      /**< CBR, high quality (slower) */
-    NV_ENC_PARAMS_RC_VBR_HQ                 = 0x20       /**< VBR, high quality (slower) */
 } NV_ENC_PARAMS_RC_MODE;
+
+/**
+ * Multi Pass encoding
+ */
+typedef enum _NV_ENC_MULTI_PASS
+{
+    NV_ENC_MULTI_PASS_DISABLED              = 0x0,        /**< Single Pass */
+    NV_ENC_TWO_PASS_QUARTER_RESOLUTION      = 0x1,        /**< Two Pass encoding is enabled where first Pass is quarter resolution */
+    NV_ENC_TWO_PASS_FULL_RESOLUTION         = 0x2,        /**< Two Pass encoding is enabled where first Pass is full resolution */
+} NV_ENC_MULTI_PASS;
+
+typedef enum _NV_ENC_STATE_RESTORE_TYPE
+{
+    NV_ENC_STATE_RESTORE_FULL               = 0x01,      /**< Restore full encoder state */
+    NV_ENC_STATE_RESTORE_RATE_CONTROL       = 0x02,      /**< Restore only rate control state */
+    NV_ENC_STATE_RESTORE_ENCODE             = 0x03,      /**< Restore full encoder state except for rate control state */
+} NV_ENC_STATE_RESTORE_TYPE;
+
+typedef enum _NV_ENC_OUTPUT_STATS_LEVEL
+{
+    NV_ENC_OUTPUT_STATS_NONE          = 0,             /** No output stats */
+    NV_ENC_OUTPUT_STATS_BLOCK_LEVEL   = 1,             /** Output stats for every block. 
+                                                           Block represents a CTB for HEVC, macroblock for H.264, super block for AV1 */
+    NV_ENC_OUTPUT_STATS_ROW_LEVEL     = 2,             /** Output stats for every row. 
+                                                           Row represents a CTB row for HEVC, macroblock row for H.264, super block row for AV1 */
+} NV_ENC_OUTPUT_STATS_LEVEL;
 
 /**
  * Emphasis Levels
@@ -278,16 +308,11 @@ typedef enum _NV_ENC_EMPHASIS_MAP_LEVEL
 typedef enum _NV_ENC_QP_MAP_MODE
 {
     NV_ENC_QP_MAP_DISABLED               = 0x0,             /**< Value in NV_ENC_PIC_PARAMS::qpDeltaMap have no effect. */
-    NV_ENC_QP_MAP_EMPHASIS               = 0x1,             /**< Value in NV_ENC_PIC_PARAMS::qpDeltaMap will be treated as Empasis level. Currently this is only supported for H264 */
+    NV_ENC_QP_MAP_EMPHASIS               = 0x1,             /**< Value in NV_ENC_PIC_PARAMS::qpDeltaMap will be treated as Emphasis level. Currently this is only supported for H264 */
     NV_ENC_QP_MAP_DELTA                  = 0x2,             /**< Value in NV_ENC_PIC_PARAMS::qpDeltaMap will be treated as QP delta map. */
     NV_ENC_QP_MAP                        = 0x3,             /**< Currently This is not supported. Value in NV_ENC_PIC_PARAMS::qpDeltaMap will be treated as QP value.   */
 } NV_ENC_QP_MAP_MODE;
 
-#define NV_ENC_PARAMS_RC_VBR_MINQP              (NV_ENC_PARAMS_RC_MODE)0x4          /**< Deprecated */
-#define NV_ENC_PARAMS_RC_2_PASS_QUALITY         NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ    /**< Deprecated */
-#define NV_ENC_PARAMS_RC_2_PASS_FRAMESIZE_CAP   NV_ENC_PARAMS_RC_CBR_HQ             /**< Deprecated */
-#define NV_ENC_PARAMS_RC_2_PASS_VBR             NV_ENC_PARAMS_RC_VBR_HQ             /**< Deprecated */
-#define NV_ENC_PARAMS_RC_CBR2                   NV_ENC_PARAMS_RC_CBR                /**< Deprecated */
 
 /**
  * Input picture structure
@@ -298,6 +323,20 @@ typedef enum _NV_ENC_PIC_STRUCT
     NV_ENC_PIC_STRUCT_FIELD_TOP_BOTTOM  = 0x02,                 /**< Field encoding top field first */
     NV_ENC_PIC_STRUCT_FIELD_BOTTOM_TOP  = 0x03                  /**< Field encoding bottom field first */
 } NV_ENC_PIC_STRUCT;
+
+/**
+ * Display picture structure
+ * Currently, this enum is only used for deciding the number of clock timestamp sets in Picture Timing SEI / Time Code SEI
+ * Otherwise, this has no impact on encoder behavior
+ */
+typedef enum _NV_ENC_DISPLAY_PIC_STRUCT
+{
+    NV_ENC_PIC_STRUCT_DISPLAY_FRAME             = 0x00,                 /**< Field encoding top field first */
+    NV_ENC_PIC_STRUCT_DISPLAY_FIELD_TOP_BOTTOM  = 0x01,                 /**< Field encoding top field first */
+    NV_ENC_PIC_STRUCT_DISPLAY_FIELD_BOTTOM_TOP  = 0x02,                 /**< Field encoding bottom field first */
+    NV_ENC_PIC_STRUCT_DISPLAY_FRAME_DOUBLING    = 0x03,                 /**< Frame doubling */
+    NV_ENC_PIC_STRUCT_DISPLAY_FRAME_TRIPLING    = 0x04                  /**< Field tripling */
+} NV_ENC_DISPLAY_PIC_STRUCT;
 
 /**
  * Input picture type
@@ -312,6 +351,7 @@ typedef enum _NV_ENC_PIC_TYPE
     NV_ENC_PIC_TYPE_SKIPPED         = 0x05,    /**< Picture is skipped */
     NV_ENC_PIC_TYPE_INTRA_REFRESH   = 0x06,    /**< First picture in intra refresh cycle */
     NV_ENC_PIC_TYPE_NONREF_P        = 0x07,    /**< Non reference P picture */
+    NV_ENC_PIC_TYPE_SWITCH          = 0x08,    /**< Switch frame (AV1 only) */
     NV_ENC_PIC_TYPE_UNKNOWN         = 0xFF     /**< Picture type unknown */
 } NV_ENC_PIC_TYPE;
 
@@ -320,10 +360,10 @@ typedef enum _NV_ENC_PIC_TYPE
  */
 typedef enum _NV_ENC_MV_PRECISION
 {
-    NV_ENC_MV_PRECISION_DEFAULT     = 0x0,       /**<Driver selects QuarterPel motion vector precision by default*/
-    NV_ENC_MV_PRECISION_FULL_PEL    = 0x01,    /**< FullPel  motion vector precision */
-    NV_ENC_MV_PRECISION_HALF_PEL    = 0x02,    /**< HalfPel motion vector precision */
-    NV_ENC_MV_PRECISION_QUARTER_PEL = 0x03     /**< QuarterPel motion vector precision */
+    NV_ENC_MV_PRECISION_DEFAULT     = 0x0,     /**< Driver selects Quarter-Pel motion vector precision by default */
+    NV_ENC_MV_PRECISION_FULL_PEL    = 0x01,    /**< Full-Pel motion vector precision */
+    NV_ENC_MV_PRECISION_HALF_PEL    = 0x02,    /**< Half-Pel motion vector precision */
+    NV_ENC_MV_PRECISION_QUARTER_PEL = 0x03     /**< Quarter-Pel motion vector precision */
 } NV_ENC_MV_PRECISION;
 
 
@@ -366,11 +406,6 @@ typedef enum _NV_ENC_BUFFER_FORMAT
                                                                              the encoded bit stream or H.264 ME only mode output. */
 } NV_ENC_BUFFER_FORMAT;
 
-#define NV_ENC_BUFFER_FORMAT_NV12_PL NV_ENC_BUFFER_FORMAT_NV12
-#define NV_ENC_BUFFER_FORMAT_YV12_PL NV_ENC_BUFFER_FORMAT_YV12
-#define NV_ENC_BUFFER_FORMAT_IYUV_PL NV_ENC_BUFFER_FORMAT_IYUV
-#define NV_ENC_BUFFER_FORMAT_YUV444_PL NV_ENC_BUFFER_FORMAT_YUV444
-
 /**
  * Encoding levels
  */
@@ -395,7 +430,9 @@ typedef enum _NV_ENC_LEVEL
     NV_ENC_LEVEL_H264_5             = 50,
     NV_ENC_LEVEL_H264_51            = 51,
     NV_ENC_LEVEL_H264_52            = 52,
-
+    NV_ENC_LEVEL_H264_60            = 60,
+    NV_ENC_LEVEL_H264_61            = 61,
+    NV_ENC_LEVEL_H264_62            = 62,
 
     NV_ENC_LEVEL_HEVC_1             = 30,
     NV_ENC_LEVEL_HEVC_2             = 60,
@@ -412,7 +449,36 @@ typedef enum _NV_ENC_LEVEL
     NV_ENC_LEVEL_HEVC_62            = 186,
 
     NV_ENC_TIER_HEVC_MAIN           = 0,
-    NV_ENC_TIER_HEVC_HIGH           = 1
+    NV_ENC_TIER_HEVC_HIGH           = 1,
+
+    NV_ENC_LEVEL_AV1_2              = 0,
+    NV_ENC_LEVEL_AV1_21             = 1,
+    NV_ENC_LEVEL_AV1_22             = 2,
+    NV_ENC_LEVEL_AV1_23             = 3,
+    NV_ENC_LEVEL_AV1_3              = 4,
+    NV_ENC_LEVEL_AV1_31             = 5,
+    NV_ENC_LEVEL_AV1_32             = 6,
+    NV_ENC_LEVEL_AV1_33             = 7,
+    NV_ENC_LEVEL_AV1_4              = 8,
+    NV_ENC_LEVEL_AV1_41             = 9,
+    NV_ENC_LEVEL_AV1_42             = 10,
+    NV_ENC_LEVEL_AV1_43             = 11,
+    NV_ENC_LEVEL_AV1_5              = 12,
+    NV_ENC_LEVEL_AV1_51             = 13,
+    NV_ENC_LEVEL_AV1_52             = 14,
+    NV_ENC_LEVEL_AV1_53             = 15,
+    NV_ENC_LEVEL_AV1_6              = 16,
+    NV_ENC_LEVEL_AV1_61             = 17,
+    NV_ENC_LEVEL_AV1_62             = 18,
+    NV_ENC_LEVEL_AV1_63             = 19,
+    NV_ENC_LEVEL_AV1_7              = 20,
+    NV_ENC_LEVEL_AV1_71             = 21,
+    NV_ENC_LEVEL_AV1_72             = 22,
+    NV_ENC_LEVEL_AV1_73             = 23,
+    NV_ENC_LEVEL_AV1_AUTOSELECT         ,
+
+    NV_ENC_TIER_AV1_0               = 0,
+    NV_ENC_TIER_AV1_1               = 1
 } NV_ENC_LEVEL;
 
 /**
@@ -584,6 +650,16 @@ typedef enum _NVENCSTATUS
      * that has not been successfully mapped.
      */
     NV_ENC_ERR_RESOURCE_NOT_MAPPED,
+    
+    /**
+     * This indicates encode driver requires more output buffers to write an output
+     * bitstream. If this error is returned from ::NvEncRestoreEncoderState() API, this
+     * is not a fatal error. If the client is encoding with B frames then,
+     * ::NvEncRestoreEncoderState() API might be requiring the extra output buffer for accomodating overlay frame output in a separate buffer, for AV1 codec.
+     * In this case, client must call NvEncRestoreEncoderState() API again with NV_ENC_RESTORE_ENCODER_STATE_PARAMS::outputBitstream as input along with 
+     * the parameters in the previous call. When operating in asynchronous mode of encoding, client must also specify NV_ENC_RESTORE_ENCODER_STATE_PARAMS::completionEvent.
+     */
+    NV_ENC_ERR_NEED_MORE_OUTPUT,
 
 } NVENCSTATUS;
 
@@ -592,12 +668,14 @@ typedef enum _NVENCSTATUS
  */
 typedef enum _NV_ENC_PIC_FLAGS
 {
-    NV_ENC_PIC_FLAG_FORCEINTRA         = 0x1,   /**< Encode the current picture as an Intra picture */
-    NV_ENC_PIC_FLAG_FORCEIDR           = 0x2,   /**< Encode the current picture as an IDR picture.
-                                                     This flag is only valid when Picture type decision is taken by the Encoder
-                                                     [_NV_ENC_INITIALIZE_PARAMS::enablePTD == 1]. */
-    NV_ENC_PIC_FLAG_OUTPUT_SPSPPS      = 0x4,   /**< Write the sequence and picture header in encoded bitstream of the current picture */
-    NV_ENC_PIC_FLAG_EOS                = 0x8,   /**< Indicates end of the input stream */
+    NV_ENC_PIC_FLAG_FORCEINTRA                = 0x1,   /**< Encode the current picture as an Intra picture */
+    NV_ENC_PIC_FLAG_FORCEIDR                  = 0x2,   /**< Encode the current picture as an IDR picture. 
+                                                            This flag is only valid when Picture type decision is taken by the Encoder
+                                                            [_NV_ENC_INITIALIZE_PARAMS::enablePTD == 1]. */
+    NV_ENC_PIC_FLAG_OUTPUT_SPSPPS             = 0x4,   /**< Write the sequence and picture header in encoded bitstream of the current picture */
+    NV_ENC_PIC_FLAG_EOS                       = 0x8,   /**< Indicates end of the input stream */ 
+    NV_ENC_PIC_FLAG_DISABLE_ENC_STATE_ADVANCE = 0x10,  /**< Do not advance encoder state during encode */ 
+    NV_ENC_PIC_FLAG_OUTPUT_RECON_FRAME        = 0x20,  /**< Write reconstructed frame */ 
 } NV_ENC_PIC_FLAGS;
 
 /**
@@ -617,7 +695,7 @@ typedef enum _NV_ENC_MEMORY_HEAP
 typedef enum _NV_ENC_BFRAME_REF_MODE
 {
     NV_ENC_BFRAME_REF_MODE_DISABLED = 0x0,          /**< B frame is not used for reference */
-    NV_ENC_BFRAME_REF_MODE_EACH     = 0x1,          /**< Each B-frame will be used for reference. currently not supported for H.264 */
+    NV_ENC_BFRAME_REF_MODE_EACH     = 0x1,          /**< Each B-frame will be used for reference */
     NV_ENC_BFRAME_REF_MODE_MIDDLE   = 0x2,          /**< Only(Number of B-frame)/2 th B-frame will be used for reference */
 } NV_ENC_BFRAME_REF_MODE;
 
@@ -632,7 +710,7 @@ typedef enum _NV_ENC_H264_ENTROPY_CODING_MODE
 } NV_ENC_H264_ENTROPY_CODING_MODE;
 
 /**
- * H.264 specific Bdirect modes
+ * H.264 specific BDirect modes
  */
 typedef enum _NV_ENC_H264_BDIRECT_MODE
 {
@@ -649,7 +727,7 @@ typedef enum _NV_ENC_H264_FMO_MODE
 {
     NV_ENC_H264_FMO_AUTOSELECT          = 0x0,          /**< FMO usage is auto selected by the encoder driver */
     NV_ENC_H264_FMO_ENABLE              = 0x1,          /**< Enable FMO */
-    NV_ENC_H264_FMO_DISABLE             = 0x2,          /**< Disble FMO */
+    NV_ENC_H264_FMO_DISABLE             = 0x2,          /**< Disable FMO */
 } NV_ENC_H264_FMO_MODE;
 
 /**
@@ -697,7 +775,8 @@ typedef enum _NV_ENC_BUFFER_USAGE
     NV_ENC_INPUT_IMAGE              = 0x0,          /**< Registered surface will be used for input image */
     NV_ENC_OUTPUT_MOTION_VECTOR     = 0x1,          /**< Registered surface will be used for output of H.264 ME only mode.
                                                          This buffer usage type is not supported for HEVC ME only mode. */
-    NV_ENC_OUTPUT_BITSTREAM         = 0x2           /**< Registered surface will be used for output bitstream in encoding */
+    NV_ENC_OUTPUT_BITSTREAM         = 0x2,          /**< Registered surface will be used for output bitstream in encoding */
+    NV_ENC_OUTPUT_RECON             = 0x4,          /**< Registered surface will be used for output reconstructed frame in encoding */
 } NV_ENC_BUFFER_USAGE;
 
 /**
@@ -726,6 +805,14 @@ typedef enum _NV_ENC_NUM_REF_FRAMES
     NV_ENC_NUM_REF_FRAMES_7                = 0x7           /**< Number of reference frames equal to 7 */
 } NV_ENC_NUM_REF_FRAMES;
 
+/**
+*  Enum for Temporal filtering level.
+*/
+typedef enum _NV_ENC_TEMPORAL_FILTER_LEVEL
+{
+    NV_ENC_TEMPORAL_FILTER_LEVEL_0 = 0,
+    NV_ENC_TEMPORAL_FILTER_LEVEL_4 = 4,
+}NV_ENC_TEMPORAL_FILTER_LEVEL;
 /**
  * Encoder capabilities enumeration.
  */
@@ -766,8 +853,8 @@ typedef enum _NV_ENC_CAPS
 
     /**
      * Indicates HW capability for Quarter pel motion estimation.
-     * \n 0 : QuarterPel Motion Estimation not supported.
-     * \n 1 : QuarterPel Motion Estimation supported.
+     * \n 0 : Quarter-Pel Motion Estimation not supported.
+     * \n 1 : Quarter-Pel Motion Estimation supported.
      */
     NV_ENC_CAPS_SUPPORT_QPELMV,
 
@@ -886,7 +973,7 @@ typedef enum _NV_ENC_CAPS
     NV_ENC_CAPS_SUPPORT_DYN_RCMODE_CHANGE,
 
     /**
-     * Indicates Subframe readback support for slice-based encoding.
+     * Indicates Subframe readback support for slice-based encoding. If this feature is supported, it can be enabled by setting enableSubFrameWrite = 1.
      * \n 0 : Subframe readback not supported.
      * \n 1 : Subframe readback supported.
      */
@@ -896,11 +983,10 @@ typedef enum _NV_ENC_CAPS
      * Indicates Constrained Encoding mode support.
      * Support added from NvEncodeAPI version 2.0.
      * \n 0 : Constrained encoding mode not supported.
-     * \n 1 : Constarined encoding mode supported.
-     * If this mode is supported client can enable this during initialisation.
+     * \n 1 : Constrained encoding mode supported.
+     * If this mode is supported client can enable this during initialization.
      * Client can then force a picture to be coded as constrained picture where
-     * each slice in a constrained picture will have constrained_intra_pred_flag set to 1
-     * and disable_deblocking_filter_idc will be set to 2 and prediction vectors for inter
+     * in-loop filtering is disabled across slice boundaries and prediction vectors for inter
      * macroblocks in each slice will be restricted to the slice region.
      */
     NV_ENC_CAPS_SUPPORT_CONSTRAINED_ENCODING,
@@ -914,7 +1000,7 @@ typedef enum _NV_ENC_CAPS
     NV_ENC_CAPS_SUPPORT_INTRA_REFRESH,
 
     /**
-     * Indicates Custom VBV Bufer Size support. It can be used for capping frame size.
+     * Indicates Custom VBV Buffer Size support. It can be used for capping frame size.
      * Support added from NvEncodeAPI version 2.0.
      * \n 0 : Custom VBV buffer size specification from client, not supported.
      * \n 1 : Custom VBV buffer size specification from client, supported.
@@ -938,7 +1024,7 @@ typedef enum _NV_ENC_CAPS
     NV_ENC_CAPS_SUPPORT_REF_PIC_INVALIDATION,
 
     /**
-     * Indicates support for PreProcessing.
+     * Indicates support for Pre-Processing.
      * The API return value is a bitmask of the values defined in ::NV_ENC_PREPROC_FLAGS
      */
     NV_ENC_CAPS_PREPROC_SUPPORT,
@@ -982,7 +1068,7 @@ typedef enum _NV_ENC_CAPS
     NV_ENC_CAPS_SUPPORT_SAO,
 
     /**
-     * Indicates HW support for MEOnly Mode.
+     * Indicates HW support for Motion Estimation Only Mode.
      * \n 0 : MEOnly Mode not supported.
      * \n 1 : MEOnly Mode supported for I and P frames.
      * \n 2 : MEOnly Mode supported for I, P and B frames.
@@ -1014,9 +1100,9 @@ typedef enum _NV_ENC_CAPS
     NV_ENC_CAPS_NUM_MAX_LTR_FRAMES,
 
     /**
-     * Indicates HW support for Weighted Predicition.
-     * \n 0 : Weighted Predicition not supported.
-     * \n 1 : Weighted Predicition supported.
+     * Indicates HW support for Weighted Prediction.
+     * \n 0 : Weighted Prediction not supported.
+     * \n 1 : Weighted Prediction supported.
      */
     NV_ENC_CAPS_SUPPORT_WEIGHTED_PREDICTION,
 
@@ -1028,12 +1114,12 @@ typedef enum _NV_ENC_CAPS
      * If the available encoder capacity is returned as zero, applications may choose to switch to software encoding
      * and continue to call this API (e.g. polling once per second) until capacity becomes available.
      *
-     * On baremetal (non-virtualized GPU) and linux platforms, this API always returns 100.
+     * On bare metal (non-virtualized GPU) and linux platforms, this API always returns 100.
      */
     NV_ENC_CAPS_DYNAMIC_QUERY_ENCODER_CAPACITY,
 
      /**
-     * Indicates B as refererence support.
+     * Indicates B as reference support.
      * \n 0 : B as reference is not supported.
      * \n 1 : each B-Frame as reference is supported.
      * \n 2 : only Middle B-frame as reference is supported.
@@ -1062,10 +1148,64 @@ typedef enum _NV_ENC_CAPS
      */
     NV_ENC_CAPS_SUPPORT_MULTIPLE_REF_FRAMES,
 
+    /**
+     * Indicates HW support for HEVC with alpha encoding.
+     * \n 0 : HEVC with alpha encoding not supported.
+     * \n 1 : HEVC with alpha encoding is supported.
+     */
+    NV_ENC_CAPS_SUPPORT_ALPHA_LAYER_ENCODING,
+
+    /**
+     * Indicates number of Encoding engines present on GPU.
+     */
+    NV_ENC_CAPS_NUM_ENCODER_ENGINES,
+
+    /**
+     * Indicates single slice intra refresh support.
+     */
+    NV_ENC_CAPS_SINGLE_SLICE_INTRA_REFRESH,
+
+    /**
+     * Indicates encoding without advancing the state support.
+     */
+    NV_ENC_CAPS_DISABLE_ENC_STATE_ADVANCE,
+
+    /**
+     * Indicates reconstructed output support.
+     */
+    NV_ENC_CAPS_OUTPUT_RECON_SURFACE,
+
+    /**
+     * Indicates encoded frame output stats support for every block. Block represents a CTB for HEVC, macroblock for H.264 and super block for AV1.
+     */
+    NV_ENC_CAPS_OUTPUT_BLOCK_STATS,
+
+    /**
+     * Indicates encoded frame output stats support for every row. Row represents a CTB row for HEVC, macroblock row for H.264 and super block row for AV1.
+     */
+    NV_ENC_CAPS_OUTPUT_ROW_STATS,
+
+
+    /**
+     * Indicates temporal filtering support.
+     */
+     NV_ENC_CAPS_SUPPORT_TEMPORAL_FILTER,
+
+    /**
+     * Maximum Lookahead level supported (See ::NV_ENC_LOOKAHEAD_LEVEL for details).
+     */
+    NV_ENC_CAPS_SUPPORT_LOOKAHEAD_LEVEL,
+
+    /**
+     * Indicates UnidirectionalB support.
+     */
+    NV_ENC_CAPS_SUPPORT_UNIDIRECTIONAL_B,
+
      /**
      * Reserved - Not to be used by clients.
      */
     NV_ENC_CAPS_EXPOSED_COUNT
+
 } NV_ENC_CAPS;
 
 /**
@@ -1079,6 +1219,112 @@ typedef enum _NV_ENC_HEVC_CUSIZE
     NV_ENC_HEVC_CUSIZE_32x32      = 3,
     NV_ENC_HEVC_CUSIZE_64x64      = 4,
 }NV_ENC_HEVC_CUSIZE;
+
+/**
+*  AV1 PART SIZE
+*/
+typedef enum _NV_ENC_AV1_PART_SIZE
+{
+    NV_ENC_AV1_PART_SIZE_AUTOSELECT    = 0,
+    NV_ENC_AV1_PART_SIZE_4x4           = 1,
+    NV_ENC_AV1_PART_SIZE_8x8           = 2,
+    NV_ENC_AV1_PART_SIZE_16x16         = 3,
+    NV_ENC_AV1_PART_SIZE_32x32         = 4,
+    NV_ENC_AV1_PART_SIZE_64x64         = 5,
+}NV_ENC_AV1_PART_SIZE;
+
+/**
+*  Enums related to fields in VUI parameters.
+*/
+typedef enum _NV_ENC_VUI_VIDEO_FORMAT
+{
+    NV_ENC_VUI_VIDEO_FORMAT_COMPONENT   = 0,
+    NV_ENC_VUI_VIDEO_FORMAT_PAL         = 1,
+    NV_ENC_VUI_VIDEO_FORMAT_NTSC        = 2,
+    NV_ENC_VUI_VIDEO_FORMAT_SECAM       = 3,
+    NV_ENC_VUI_VIDEO_FORMAT_MAC         = 4,
+    NV_ENC_VUI_VIDEO_FORMAT_UNSPECIFIED = 5,
+}NV_ENC_VUI_VIDEO_FORMAT;
+
+typedef enum _NV_ENC_VUI_COLOR_PRIMARIES
+{
+    NV_ENC_VUI_COLOR_PRIMARIES_UNDEFINED   = 0,
+    NV_ENC_VUI_COLOR_PRIMARIES_BT709       = 1,
+    NV_ENC_VUI_COLOR_PRIMARIES_UNSPECIFIED = 2,
+    NV_ENC_VUI_COLOR_PRIMARIES_RESERVED    = 3,
+    NV_ENC_VUI_COLOR_PRIMARIES_BT470M      = 4,
+    NV_ENC_VUI_COLOR_PRIMARIES_BT470BG     = 5,
+    NV_ENC_VUI_COLOR_PRIMARIES_SMPTE170M   = 6,
+    NV_ENC_VUI_COLOR_PRIMARIES_SMPTE240M   = 7,
+    NV_ENC_VUI_COLOR_PRIMARIES_FILM        = 8,
+    NV_ENC_VUI_COLOR_PRIMARIES_BT2020      = 9,
+    NV_ENC_VUI_COLOR_PRIMARIES_SMPTE428    = 10,
+    NV_ENC_VUI_COLOR_PRIMARIES_SMPTE431    = 11,
+    NV_ENC_VUI_COLOR_PRIMARIES_SMPTE432    = 12,
+    NV_ENC_VUI_COLOR_PRIMARIES_JEDEC_P22   = 22,
+}NV_ENC_VUI_COLOR_PRIMARIES;
+
+typedef enum _NV_ENC_VUI_TRANSFER_CHARACTERISTIC
+{
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_UNDEFINED     = 0,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT709         = 1,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_UNSPECIFIED   = 2,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_RESERVED      = 3,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT470M        = 4,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT470BG       = 5,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_SMPTE170M     = 6,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_SMPTE240M     = 7,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_LINEAR        = 8,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_LOG           = 9,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_LOG_SQRT      = 10,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_IEC61966_2_4  = 11,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT1361_ECG    = 12,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_SRGB          = 13,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT2020_10     = 14,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT2020_12     = 15,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_SMPTE2084     = 16,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_SMPTE428      = 17,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_ARIB_STD_B67  = 18,
+}NV_ENC_VUI_TRANSFER_CHARACTERISTIC;
+
+typedef enum _NV_ENC_VUI_MATRIX_COEFFS
+{
+    NV_ENC_VUI_MATRIX_COEFFS_RGB         = 0,
+    NV_ENC_VUI_MATRIX_COEFFS_BT709       = 1,
+    NV_ENC_VUI_MATRIX_COEFFS_UNSPECIFIED = 2,
+    NV_ENC_VUI_MATRIX_COEFFS_RESERVED    = 3,
+    NV_ENC_VUI_MATRIX_COEFFS_FCC         = 4,
+    NV_ENC_VUI_MATRIX_COEFFS_BT470BG     = 5,
+    NV_ENC_VUI_MATRIX_COEFFS_SMPTE170M   = 6,
+    NV_ENC_VUI_MATRIX_COEFFS_SMPTE240M   = 7,
+    NV_ENC_VUI_MATRIX_COEFFS_YCGCO       = 8,
+    NV_ENC_VUI_MATRIX_COEFFS_BT2020_NCL  = 9,
+    NV_ENC_VUI_MATRIX_COEFFS_BT2020_CL   = 10,
+    NV_ENC_VUI_MATRIX_COEFFS_SMPTE2085   = 11,
+}NV_ENC_VUI_MATRIX_COEFFS;
+
+
+/**
+*  Enum for Lookahead level.
+*/
+typedef enum _NV_ENC_LOOKAHEAD_LEVEL
+{
+    NV_ENC_LOOKAHEAD_LEVEL_0             = 0,
+    NV_ENC_LOOKAHEAD_LEVEL_1             = 1,
+    NV_ENC_LOOKAHEAD_LEVEL_2             = 2,
+    NV_ENC_LOOKAHEAD_LEVEL_3             = 3,
+    NV_ENC_LOOKAHEAD_LEVEL_AUTOSELECT    = 15,
+}NV_ENC_LOOKAHEAD_LEVEL;
+
+/**
+* Enum for Bit Depth
+*/
+typedef enum _NV_ENC_BIT_DEPTH
+{
+    NV_ENC_BIT_DEPTH_INVALID             = 0,         /**< Invalid Bit Depth */
+    NV_ENC_BIT_DEPTH_8                   = 8,         /**< Bit Depth 8 */
+    NV_ENC_BIT_DEPTH_10                  = 10,        /**< Bit Depth 10 */
+}NV_ENC_BIT_DEPTH;
 
 /**
  * Input struct for querying Encoding capabilities.
@@ -1095,6 +1341,56 @@ typedef struct _NV_ENC_CAPS_PARAM
 
 
 /**
+ * Restore encoder state parameters
+ */
+typedef struct _NV_ENC_RESTORE_ENCODER_STATE_PARAMS
+{
+    uint32_t                  version;                 /**< [in]: Struct version. */
+    uint32_t                  bufferIdx;               /**< [in]: State buffer index to which the encoder state will be restored */
+    NV_ENC_STATE_RESTORE_TYPE state;                   /**< [in]: State type to restore */
+    uint32_t                  reserved;                /**< [in]: Reserved and must be set to 0 */
+    NV_ENC_OUTPUT_PTR         outputBitstream;         /**< [in]: Specifies the output buffer pointer, for AV1 encode only. 
+                                                                  Application must call NvEncRestoreEncoderState() API with _NV_ENC_RESTORE_ENCODER_STATE_PARAMS::outputBitstream and 
+                                                                  _NV_ENC_RESTORE_ENCODER_STATE_PARAMS::completionEvent as input when an earlier call to this API returned "NV_ENC_ERR_NEED_MORE_OUTPUT", for AV1 encode. */
+    void*                     completionEvent;         /**< [in]: Specifies the completion event when asynchronous mode of encoding is enabled. Used for AV1 encode only. */
+    uint32_t                  reserved1[64];           /**< [in]: Reserved and must be set to 0 */
+    void*                     reserved2[64];           /**< [in]: Reserved and must be set to NULL */
+} NV_ENC_RESTORE_ENCODER_STATE_PARAMS;
+
+/** NV_ENC_RESTORE_ENCODER_STATE_PARAMS struct version. */
+#define NV_ENC_RESTORE_ENCODER_STATE_PARAMS_VER NVENCAPI_STRUCT_VERSION(2)
+
+/**
+ * Encoded frame information parameters for every block.
+ */
+typedef struct _NV_ENC_OUTPUT_STATS_BLOCK
+{
+   uint32_t                 version;                /**< [in]: Struct version */
+   uint8_t                  QP;                     /**< [out]: QP of the block */
+   uint8_t                  reserved[3];            /**< [in]: Reserved and must be set to 0 */
+   uint32_t                 bitcount;               /**< [out]: Bitcount of the block */
+   uint32_t                 reserved1[13];          /**< [in]: Reserved and must be set to 0 */
+} NV_ENC_OUTPUT_STATS_BLOCK;
+
+/** NV_ENC_OUTPUT_STATS_BLOCK struct version. */
+#define NV_ENC_OUTPUT_STATS_BLOCK_VER NVENCAPI_STRUCT_VERSION(1)
+
+/**
+ * Encoded frame information parameters for every row.
+ */
+typedef struct _NV_ENC_OUTPUT_STATS_ROW
+{
+   uint32_t                 version;                /**< [in]: Struct version */
+   uint8_t                  QP;                     /**< [out]: QP of the row */
+   uint8_t                  reserved[3];            /**< [in]: Reserved and must be set to 0 */
+   uint32_t                 bitcount;               /**< [out]: Bitcount of the row */
+   uint32_t                 reserved1[13];          /**< [in]: Reserved and must be set to 0 */
+} NV_ENC_OUTPUT_STATS_ROW;
+
+/** NV_ENC_OUTPUT_STATS_ROW struct version. */
+#define NV_ENC_OUTPUT_STATS_ROW_VER NVENCAPI_STRUCT_VERSION(1)
+
+/**
  * Encoder Output parameters
  */
 typedef struct _NV_ENC_ENCODE_OUT_PARAMS
@@ -1108,24 +1404,40 @@ typedef struct _NV_ENC_ENCODE_OUT_PARAMS
 #define NV_ENC_ENCODE_OUT_PARAMS_VER NVENCAPI_STRUCT_VERSION(1)
 
 /**
+ * Lookahead picture parameters
+ */
+typedef struct _NV_ENC_LOOKAHEAD_PIC_PARAMS
+{
+    uint32_t                  version;                 /**< [in]: Struct version. */
+    uint32_t                  reserved;                /**< [in]: Reserved and must be set to 0 */
+    NV_ENC_INPUT_PTR          inputBuffer;             /**< [in]: Specifies the input buffer pointer. Client must use a pointer obtained from ::NvEncCreateInputBuffer() or ::NvEncMapInputResource() APIs.*/
+    NV_ENC_PIC_TYPE           pictureType;             /**< [in]: Specifies input picture type. Client required to be set explicitly by the client if the client has not set NV_ENC_INITALIZE_PARAMS::enablePTD to 1 while calling NvInitializeEncoder. */
+    uint32_t                  reserved1[63];            /**< [in]: Reserved and must be set to 0 */
+    void*                     reserved2[64];           /**< [in]: Reserved and must be set to NULL */
+} NV_ENC_LOOKAHEAD_PIC_PARAMS;
+
+/** NV_ENC_LOOKAHEAD_PIC_PARAMS struct version. */
+#define NV_ENC_LOOKAHEAD_PIC_PARAMS_VER NVENCAPI_STRUCT_VERSION(2)
+
+/**
  * Creation parameters for input buffer.
  */
 typedef struct _NV_ENC_CREATE_INPUT_BUFFER
 {
     uint32_t                  version;                 /**< [in]: Struct version. Must be set to ::NV_ENC_CREATE_INPUT_BUFFER_VER */
-    uint32_t                  width;                   /**< [in]: Input buffer width */
-    uint32_t                  height;                  /**< [in]: Input buffer width */
+    uint32_t                  width;                   /**< [in]: Input frame width */
+    uint32_t                  height;                  /**< [in]: Input frame height */
     NV_ENC_MEMORY_HEAP        memoryHeap;              /**< [in]: Deprecated. Do not use */
     NV_ENC_BUFFER_FORMAT      bufferFmt;               /**< [in]: Input buffer format */
     uint32_t                  reserved;                /**< [in]: Reserved and must be set to 0 */
     NV_ENC_INPUT_PTR          inputBuffer;             /**< [out]: Pointer to input buffer */
-    void*                     pSysMemBuffer;           /**< [in]: Pointer to existing sysmem buffer */
-    uint32_t                  reserved1[57];           /**< [in]: Reserved and must be set to 0 */
+    void*                     pSysMemBuffer;           /**< [in]: Pointer to existing system memory buffer */
+    uint32_t                  reserved1[58];           /**< [in]: Reserved and must be set to 0 */
     void*                     reserved2[63];           /**< [in]: Reserved and must be set to NULL */
 } NV_ENC_CREATE_INPUT_BUFFER;
 
 /** NV_ENC_CREATE_INPUT_BUFFER struct version. */
-#define NV_ENC_CREATE_INPUT_BUFFER_VER NVENCAPI_STRUCT_VERSION(1)
+#define NV_ENC_CREATE_INPUT_BUFFER_VER NVENCAPI_STRUCT_VERSION(2)
 
 /**
  * Creation parameters for output bitstream buffer.
@@ -1150,8 +1462,8 @@ typedef struct _NV_ENC_CREATE_BITSTREAM_BUFFER
  */
 typedef struct _NV_ENC_MVECTOR
 {
-    int16_t             mvx;               /**< the x component of MV in qpel units */
-    int16_t             mvy;               /**< the y component of MV in qpel units */
+    int16_t             mvx;               /**< the x component of MV in quarter-pel units */
+    int16_t             mvy;               /**< the y component of MV in quarter-pel units */
 } NV_ENC_MVECTOR;
 
 /**
@@ -1186,13 +1498,14 @@ typedef struct _NV_ENC_HEVC_MV_DATA
 typedef struct _NV_ENC_CREATE_MV_BUFFER
 {
     uint32_t            version;           /**< [in]: Struct version. Must be set to NV_ENC_CREATE_MV_BUFFER_VER */
+    uint32_t            reserved;          /**< [in]: Reserved and should be set to 0 */
     NV_ENC_OUTPUT_PTR   mvBuffer;          /**< [out]: Pointer to the output motion vector buffer */
-    uint32_t            reserved1[255];    /**< [in]: Reserved and should be set to 0 */
+    uint32_t            reserved1[254];    /**< [in]: Reserved and should be set to 0 */
     void*               reserved2[63];     /**< [in]: Reserved and should be set to NULL */
 } NV_ENC_CREATE_MV_BUFFER;
 
 /** NV_ENC_CREATE_MV_BUFFER struct version*/
-#define NV_ENC_CREATE_MV_BUFFER_VER NVENCAPI_STRUCT_VERSION(1)
+#define NV_ENC_CREATE_MV_BUFFER_VER NVENCAPI_STRUCT_VERSION(2)
 
 /**
  * QP value for frames
@@ -1205,7 +1518,7 @@ typedef struct _NV_ENC_QP
 } NV_ENC_QP;
 
 /**
- * Rate Control Configuration Paramters
+ * Rate Control Configuration Parameters
  */
  typedef struct _NV_ENC_RC_PARAMS
  {
@@ -1218,7 +1531,7 @@ typedef struct _NV_ENC_QP
     uint32_t                        vbvInitialDelay;                             /**< [in]: Specifies the VBV(HRD) initial delay in bits. Set 0 to use the default VBV  initial delay .*/
     uint32_t                        enableMinQP          :1;                     /**< [in]: Set this to 1 if minimum QP used for rate control. */
     uint32_t                        enableMaxQP          :1;                     /**< [in]: Set this to 1 if maximum QP used for rate control. */
-    uint32_t                        enableInitialRCQP    :1;                     /**< [in]: Set this to 1 if user suppplied initial QP is used for rate control. */
+    uint32_t                        enableInitialRCQP    :1;                     /**< [in]: Set this to 1 if user supplied initial QP is used for rate control. */
     uint32_t                        enableAQ             :1;                     /**< [in]: Set this to 1 to enable adaptive quantization (Spatial). */
     uint32_t                        reservedBitField1    :1;                     /**< [in]: Reserved bitfields and must be set to 0. */
     uint32_t                        enableLookahead      :1;                     /**< [in]: Set this to 1 to enable lookahead with depth <lookaheadDepth> (if lookahead is enabled, input frames must remain available to the encoder until encode completion) */
@@ -1228,40 +1541,89 @@ typedef struct _NV_ENC_QP
     uint32_t                        zeroReorderDelay     :1;                     /**< [in]: Set this to 1 to indicate zero latency operation (no reordering delay, num_reorder_frames=0) */
     uint32_t                        enableNonRefP        :1;                     /**< [in]: Set this to 1 to enable automatic insertion of non-reference P-frames (no effect if enablePTD=0) */
     uint32_t                        strictGOPTarget      :1;                     /**< [in]: Set this to 1 to minimize GOP-to-GOP rate fluctuations */
-    uint32_t                        aqStrength           :4;                     /**< [in]: When AQ (Spatial) is enabled (i.e. NV_ENC_RC_PARAMS::enableAQ is set), this field is used to specify AQ strength. AQ strength scale is from 1 (low) - 15 (aggressive). If not set, strength is autoselected by driver. */
-    uint32_t                        reservedBitFields    :16;                    /**< [in]: Reserved bitfields and must be set to 0 */
+    uint32_t                        aqStrength           :4;                     /**< [in]: When AQ (Spatial) is enabled (i.e. NV_ENC_RC_PARAMS::enableAQ is set), this field is used to specify AQ strength. AQ strength scale is from 1 (low) - 15 (aggressive).
+                                                                                            If not set, strength is auto selected by driver. */
+    uint32_t                        enableExtLookahead   :1;                     /**< [in]: Set this to 1 to enable lookahead externally. 
+                                                                                            Application must call NvEncLookahead() for NV_ENC_RC_PARAMS::lookaheadDepth number of frames,
+                                                                                            before calling NvEncEncodePicture() for the first frame */
+    uint32_t                        reservedBitFields    :15;                    /**< [in]: Reserved bitfields and must be set to 0 */
     NV_ENC_QP                       minQP;                                       /**< [in]: Specifies the minimum QP used for rate control. Client must set NV_ENC_CONFIG::enableMinQP to 1. */
     NV_ENC_QP                       maxQP;                                       /**< [in]: Specifies the maximum QP used for rate control. Client must set NV_ENC_CONFIG::enableMaxQP to 1. */
-    NV_ENC_QP                       initialRCQP;                                 /**< [in]: Specifies the initial QP used for rate control. Client must set NV_ENC_CONFIG::enableInitialRCQP to 1. */
-    uint32_t                        temporallayerIdxMask;                        /**< [in]: Specifies the temporal layers (as a bitmask) whose QPs have changed. Valid max bitmask is [2^NV_ENC_CAPS_NUM_MAX_TEMPORAL_LAYERS - 1] */
-    uint8_t                         temporalLayerQP[8];                          /**< [in]: Specifies the temporal layer QPs used for rate control. Temporal layer index is used as as the array index */
+    NV_ENC_QP                       initialRCQP;                                 /**< [in]: Specifies the initial QP hint used for rate control. The parameter is just used as hint to influence the QP difference between I,P and B frames.
+                                                                                            Client must set NV_ENC_CONFIG::enableInitialRCQP to 1. */
+    uint32_t                        temporallayerIdxMask;                        /**< [in]: Specifies the temporal layers (as a bitmask) whose QPs have changed. Valid max bitmask is [2^NV_ENC_CAPS_NUM_MAX_TEMPORAL_LAYERS - 1].
+                                                                                            Applicable only for constant QP mode (NV_ENC_RC_PARAMS::rateControlMode = NV_ENC_PARAMS_RC_CONSTQP). */
+    uint8_t                         temporalLayerQP[8];                          /**< [in]: Specifies the temporal layer QPs used for rate control. Temporal layer index is used as the array index.
+                                                                                            Applicable only for constant QP mode (NV_ENC_RC_PARAMS::rateControlMode = NV_ENC_PARAMS_RC_CONSTQP). */
     uint8_t                         targetQuality;                               /**< [in]: Target CQ (Constant Quality) level for VBR mode (range 0-51 with 0-automatic)  */
     uint8_t                         targetQualityLSB;                            /**< [in]: Fractional part of target quality (as 8.8 fixed point format) */
-    uint16_t                        lookaheadDepth;                              /**< [in]: Maximum depth of lookahead with range 0-32 (only used if enableLookahead=1) */
-    uint32_t                        reserved1;
+    uint16_t                        lookaheadDepth;                              /**< [in]: Maximum depth of lookahead with range 0-(31 - number of B frames).
+                                                                                            lookaheadDepth is only used if enableLookahead=1.*/
+    uint8_t                         lowDelayKeyFrameScale;                       /**< [in]: Specifies the ratio of I frame bits to P frame bits in case of single frame VBV and CBR rate control mode,
+                                                                                            is set to 2 by default for low latency tuning info and 1 by default for ultra low latency tuning info  */
+    int8_t                          yDcQPIndexOffset;                            /**< [in]: Specifies the value of 'deltaQ_y_dc' in AV1.*/
+    int8_t                          uDcQPIndexOffset;                            /**< [in]: Specifies the value of 'deltaQ_u_dc' in AV1.*/
+    int8_t                          vDcQPIndexOffset;                            /**< [in]: Specifies the value of 'deltaQ_v_dc' in AV1 (for future use only - deltaQ_v_dc is currently always internally set to same value as deltaQ_u_dc). */
     NV_ENC_QP_MAP_MODE              qpMapMode;                                   /**< [in]: This flag is used to interpret values in array specified by NV_ENC_PIC_PARAMS::qpDeltaMap.
                                                                                             Set this to NV_ENC_QP_MAP_EMPHASIS to treat values specified by NV_ENC_PIC_PARAMS::qpDeltaMap as Emphasis Level Map.
                                                                                             Emphasis Level can be assigned any value specified in enum NV_ENC_EMPHASIS_MAP_LEVEL.
                                                                                             Emphasis Level Map is used to specify regions to be encoded at varying levels of quality.
                                                                                             The hardware encoder adjusts the quantization within the image as per the provided emphasis map,
-                                                                                            by adjusting the quantization parameter (QP) assigned to each macroblock. This adjustment is commonly called “Delta QP”.
-                                                                                            The adjustment depends on the absolute QP decided by the rate control algorithm, and is applied after the rate control has decided each macroblock’s QP.
+                                                                                            by adjusting the quantization parameter (QP) assigned to each macroblock. This adjustment is commonly called "Delta QP".
+                                                                                            The adjustment depends on the absolute QP decided by the rate control algorithm, and is applied after the rate control has decided each macroblock's QP.
                                                                                             Since the Delta QP overrides rate control, enabling Emphasis Level Map may violate bitrate and VBV buffer size constraints.
                                                                                             Emphasis Level Map is useful in situations where client has a priori knowledge of the image complexity (e.g. via use of NVFBC's Classification feature) and encoding those high-complexity areas at higher quality (lower QP) is important, even at the possible cost of violating bitrate/VBV buffer size constraints
                                                                                             This feature is not supported when AQ( Spatial/Temporal) is enabled.
                                                                                             This feature is only supported for H264 codec currently.
 
-                                                                                            Set this to NV_ENC_QP_MAP_DELTA to treat values specified by NV_ENC_PIC_PARAMS::qpDeltaMap as QPDelta. This specifies QP modifier to be applied on top of the QP chosen by rate control
+                                                                                            Set this to NV_ENC_QP_MAP_DELTA to treat values specified by NV_ENC_PIC_PARAMS::qpDeltaMap as QP Delta. This specifies QP modifier to be applied on top of the QP chosen by rate control
 
                                                                                             Set this to NV_ENC_QP_MAP_DISABLED to ignore NV_ENC_PIC_PARAMS::qpDeltaMap values. In this case, qpDeltaMap should be set to NULL.
 
                                                                                             Other values are reserved for future use.*/
-    uint32_t                        reserved[7];
+    NV_ENC_MULTI_PASS               multiPass;                                    /**< [in]: This flag is used to enable multi-pass encoding for a given ::NV_ENC_PARAMS_RC_MODE. This flag is not valid for H264 and HEVC MEOnly mode */
+    uint32_t                        alphaLayerBitrateRatio;                       /**< [in]: Specifies the ratio in which bitrate should be split between base and alpha layer. A value 'x' for this field will split the target bitrate in a ratio of x : 1 between base and alpha layer.
+                                                                                             The default split ratio is 15.*/
+    int8_t                          cbQPIndexOffset;                              /**< [in]: Specifies the value of 'chroma_qp_index_offset' in H264 / 'pps_cb_qp_offset' in HEVC / 'deltaQ_u_ac' in AV1.*/
+    int8_t                          crQPIndexOffset;                              /**< [in]: Specifies the value of 'second_chroma_qp_index_offset' in H264 / 'pps_cr_qp_offset' in HEVC / 'deltaQ_v_ac' in AV1 (for future use only - deltaQ_v_ac is currently always internally set to same value as deltaQ_u_ac). */
+    uint16_t                        reserved2;
+    NV_ENC_LOOKAHEAD_LEVEL          lookaheadLevel;                               /**< [in]: Specifies the lookahead level. Higher level may improve quality at the expense of performance. */
+    uint32_t                        reserved[3];
  } NV_ENC_RC_PARAMS;
 
 /** macro for constructing the version field of ::_NV_ENC_RC_PARAMS */
 #define NV_ENC_RC_PARAMS_VER NVENCAPI_STRUCT_VERSION(1)
 
+#define MAX_NUM_CLOCK_TS    3
+
+/**
+* Clock Timestamp set parameters
+* For H264, this structure is used to populate Picture Timing SEI when NV_ENC_CONFIG_H264::enableTimeCode is set to 1.
+* For HEVC, this structure is used to populate Time Code SEI when NV_ENC_CONFIG_HEVC::enableTimeCodeSEI is set to 1.
+* For more details, refer to Annex D of ITU-T Specification.
+*/
+
+typedef struct _NV_ENC_CLOCK_TIMESTAMP_SET
+{
+    uint32_t        countingType            : 1;    /**< [in] Specifies the 'counting_type' */
+    uint32_t        discontinuityFlag       : 1;    /**< [in] Specifies the 'discontinuity_flag' */
+    uint32_t        cntDroppedFrames        : 1;    /**< [in] Specifies the 'cnt_dropped_flag' */
+    uint32_t        nFrames                 : 8;    /**< [in] Specifies the value of 'n_frames' */
+    uint32_t        secondsValue            : 6;    /**< [in] Specifies the 'seconds_value' */
+    uint32_t        minutesValue            : 6;    /**< [in] Specifies the 'minutes_value' */
+    uint32_t        hoursValue              : 5;    /**< [in] Specifies the 'hours_value' */
+    uint32_t        reserved2               : 4;    /**< [in] Reserved and must be set to 0 */
+    uint32_t        timeOffset;                     /**< [in] Specifies the 'time_offset_value' */
+} NV_ENC_CLOCK_TIMESTAMP_SET;
+
+typedef struct _NV_ENC_TIME_CODE
+{
+    NV_ENC_DISPLAY_PIC_STRUCT       displayPicStruct;                   /**< [in] Display picStruct */
+    NV_ENC_CLOCK_TIMESTAMP_SET      clockTimestamp[MAX_NUM_CLOCK_TS];   /**< [in] Clock Timestamp set */
+    uint32_t                        skipClockTimestampInsertion;        /**< [in] 0 : Inserts Clock Timestamp if NV_ENC_CONFIG_H264::enableTimeCode (H264) or 
+                                                                                      NV_ENC_CONFIG_HEVC::outputTimeCodeSEI (HEVC) is specified 
+                                                                                  1 : Skips insertion of Clock Timestamp for current frame */
+} NV_ENC_TIME_CODE;
 
 
 /**
@@ -1270,20 +1632,24 @@ typedef struct _NV_ENC_QP
  */
 typedef struct _NV_ENC_CONFIG_H264_VUI_PARAMETERS
 {
-    uint32_t    overscanInfoPresentFlag;              /**< [in]: if set to 1 , it specifies that the overscanInfo is present */
-    uint32_t    overscanInfo;                         /**< [in]: Specifies the overscan info(as defined in Annex E of the ITU-T Specification). */
-    uint32_t    videoSignalTypePresentFlag;           /**< [in]: If set to 1, it specifies  that the videoFormat, videoFullRangeFlag and colourDescriptionPresentFlag are present. */
-    uint32_t    videoFormat;                          /**< [in]: Specifies the source video format(as defined in Annex E of the ITU-T Specification).*/
-    uint32_t    videoFullRangeFlag;                   /**< [in]: Specifies the output range of the luma and chroma samples(as defined in Annex E of the ITU-T Specification). */
-    uint32_t    colourDescriptionPresentFlag;         /**< [in]: If set to 1, it specifies that the colourPrimaries, transferCharacteristics and colourMatrix are present. */
-    uint32_t    colourPrimaries;                      /**< [in]: Specifies color primaries for converting to RGB(as defined in Annex E of the ITU-T Specification) */
-    uint32_t    transferCharacteristics;              /**< [in]: Specifies the opto-electronic transfer characteristics to use (as defined in Annex E of the ITU-T Specification) */
-    uint32_t    colourMatrix;                         /**< [in]: Specifies the matrix coefficients used in deriving the luma and chroma from the RGB primaries (as defined in Annex E of the ITU-T Specification). */
-    uint32_t    chromaSampleLocationFlag;             /**< [in]: if set to 1 , it specifies that the chromaSampleLocationTop and chromaSampleLocationBot are present.*/
-    uint32_t    chromaSampleLocationTop;              /**< [in]: Specifies the chroma sample location for top field(as defined in Annex E of the ITU-T Specification) */
-    uint32_t    chromaSampleLocationBot;              /**< [in]: Specifies the chroma sample location for bottom field(as defined in Annex E of the ITU-T Specification) */
-    uint32_t    bitstreamRestrictionFlag;             /**< [in]: if set to 1, it specifies the bitstream restriction parameters are present in the bitstream.*/
-    uint32_t    reserved[15];
+    uint32_t                            overscanInfoPresentFlag;        /**< [in]: If set to 1 , it specifies that the overscanInfo is present */
+    uint32_t                            overscanInfo;                   /**< [in]: Specifies the overscan info(as defined in Annex E of the ITU-T Specification). */
+    uint32_t                            videoSignalTypePresentFlag;     /**< [in]: If set to 1, it specifies  that the videoFormat, videoFullRangeFlag and colourDescriptionPresentFlag are present. */
+    NV_ENC_VUI_VIDEO_FORMAT             videoFormat;                    /**< [in]: Specifies the source video format(as defined in Annex E of the ITU-T Specification).*/
+    uint32_t                            videoFullRangeFlag;             /**< [in]: Specifies the output range of the luma and chroma samples(as defined in Annex E of the ITU-T Specification). */
+    uint32_t                            colourDescriptionPresentFlag;   /**< [in]: If set to 1, it specifies that the colourPrimaries, transferCharacteristics and colourMatrix are present. */
+    NV_ENC_VUI_COLOR_PRIMARIES          colourPrimaries;                /**< [in]: Specifies color primaries for converting to RGB(as defined in Annex E of the ITU-T Specification) */
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC  transferCharacteristics;        /**< [in]: Specifies the opto-electronic transfer characteristics to use (as defined in Annex E of the ITU-T Specification) */
+    NV_ENC_VUI_MATRIX_COEFFS            colourMatrix;                   /**< [in]: Specifies the matrix coefficients used in deriving the luma and chroma from the RGB primaries (as defined in Annex E of the ITU-T Specification). */
+    uint32_t                            chromaSampleLocationFlag;       /**< [in]: If set to 1 , it specifies that the chromaSampleLocationTop and chromaSampleLocationBot are present.*/
+    uint32_t                            chromaSampleLocationTop;        /**< [in]: Specifies the chroma sample location for top field(as defined in Annex E of the ITU-T Specification) */
+    uint32_t                            chromaSampleLocationBot;        /**< [in]: Specifies the chroma sample location for bottom field(as defined in Annex E of the ITU-T Specification) */
+    uint32_t                            bitstreamRestrictionFlag;       /**< [in]: If set to 1, it specifies the bitstream restriction parameters are present in the bitstream.*/
+    uint32_t                            timingInfoPresentFlag;          /**< [in]: If set to 1, it specifies that the timingInfo is present and the 'numUnitInTicks' and 'timeScale' fields are specified by the application. */
+                                                                        /**< [in]: If not set, the timingInfo may still be present with timing related fields calculated internally basedon the frame rate specified by the application. */
+    uint32_t                            numUnitInTicks;                 /**< [in]: Specifies the number of time units of the clock(as defined in Annex E of the ITU-T Specification). */
+    uint32_t                            timeScale;                      /**< [in]: Specifies the frquency of the clock(as defined in Annex E of the ITU-T Specification). */
+    uint32_t                            reserved[12];                   /**< [in]: Reserved and must be set to 0 */
 }NV_ENC_CONFIG_H264_VUI_PARAMETERS;
 
 typedef NV_ENC_CONFIG_H264_VUI_PARAMETERS NV_ENC_CONFIG_HEVC_VUI_PARAMETERS;
@@ -1291,22 +1657,23 @@ typedef NV_ENC_CONFIG_H264_VUI_PARAMETERS NV_ENC_CONFIG_HEVC_VUI_PARAMETERS;
 /**
  * \struct _NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE
  * External motion vector hint counts per block type.
- * H264 supports multiple hint while HEVC supports one hint for each valid candidate.
+ * H264 and AV1 support multiple hint while HEVC supports one hint for each valid candidate.
  */
 typedef struct _NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE
 {
-    uint32_t   numCandsPerBlk16x16                   : 4;   /**< [in]: Supported for H264,HEVC.It Specifies the number of candidates per 16x16 block. */
-    uint32_t   numCandsPerBlk16x8                    : 4;   /**< [in]: Supported for H264 only.Specifies the number of candidates per 16x8 block. */
-    uint32_t   numCandsPerBlk8x16                    : 4;   /**< [in]: Supported for H264 only.Specifies the number of candidates per 8x16 block. */
-    uint32_t   numCandsPerBlk8x8                     : 4;   /**< [in]: Supported for H264,HEVC.Specifies the number of candidates per 8x8 block. */
-    uint32_t   reserved                              : 16;  /**< [in]: Reserved for padding. */
+    uint32_t   numCandsPerBlk16x16                   : 4;   /**< [in]: Supported for H264, HEVC. It Specifies the number of candidates per 16x16 block. */
+    uint32_t   numCandsPerBlk16x8                    : 4;   /**< [in]: Supported for H264 only. Specifies the number of candidates per 16x8 block. */
+    uint32_t   numCandsPerBlk8x16                    : 4;   /**< [in]: Supported for H264 only. Specifies the number of candidates per 8x16 block. */
+    uint32_t   numCandsPerBlk8x8                     : 4;   /**< [in]: Supported for H264, HEVC. Specifies the number of candidates per 8x8 block. */
+    uint32_t   numCandsPerSb                         : 8;   /**< [in]: Supported for AV1 only. Specifies the number of candidates per SB. */
+    uint32_t   reserved                              : 8;   /**< [in]: Reserved for padding. */
     uint32_t   reserved1[3];                                /**< [in]: Reserved for future use. */
 } NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE;
 
 
 /**
  * \struct _NVENC_EXTERNAL_ME_HINT
- * External Motion Vector hint structure.
+ * External Motion Vector hint structure for H264 and HEVC.
  */
 typedef struct _NVENC_EXTERNAL_ME_HINT
 {
@@ -1319,6 +1686,26 @@ typedef struct _NVENC_EXTERNAL_ME_HINT
     int32_t    lastOfMB    : 1;                         /**< [in]: Set to 1 for the last MV of macroblock. */
 } NVENC_EXTERNAL_ME_HINT;
 
+/**
+ * \struct _NVENC_EXTERNAL_ME_SB_HINT
+ * External Motion Vector SB hint structure for AV1
+ */
+typedef struct _NVENC_EXTERNAL_ME_SB_HINT
+{
+    int16_t    refidx         : 5;                      /**< [in]: Specifies the reference index (31=invalid) */
+    int16_t    direction      : 1;                      /**< [in]: Specifies the direction of motion estimation . 0=L0 1=L1.*/
+    int16_t    bi             : 1;                      /**< [in]: Specifies reference mode 0=single mv, 1=compound mv */
+    int16_t    partition_type : 3;                      /**< [in]: Specifies the partition type: 0: 2NX2N, 1:2NxN, 2:Nx2N. reserved 3bits for future modes */
+    int16_t    x8             : 3;                      /**< [in]: Specifies the current partition's top left x position in 8 pixel unit */
+    int16_t    last_of_cu     : 1;                      /**< [in]: Set to 1 for the last MV current CU */
+    int16_t    last_of_sb     : 1;                      /**< [in]: Set to 1 for the last MV of current SB */
+    int16_t    reserved0      : 1;                      /**< [in]: Reserved and must be set to 0 */
+    int16_t    mvx            : 14;                     /**< [in]: Specifies the x component of integer pixel MV (relative to current MB) S12.2. */
+    int16_t    cu_size        : 2;                      /**< [in]: Specifies the CU size: 0: 8x8, 1: 16x16, 2:32x32, 3:64x64 */
+    int16_t    mvy            : 12;                     /**< [in]: Specifies the y component of integer pixel MV (relative to current MB) S10.2 .*/
+    int16_t    y8             : 3;                      /**< [in]: Specifies the current partition's top left y position in 8 pixel unit */
+    int16_t    reserved1      : 1;                      /**< [in]: Reserved and must be set to 0 */
+} NVENC_EXTERNAL_ME_SB_HINT;
 
 /**
  * \struct _NV_ENC_CONFIG_H264
@@ -1326,25 +1713,23 @@ typedef struct _NVENC_EXTERNAL_ME_HINT
  */
 typedef struct _NV_ENC_CONFIG_H264
 {
-    uint32_t reserved                  :1;                          /**< [in]: Reserved and must be set to 0 */
+    uint32_t enableTemporalSVC         :1;                          /**< [in]: Set to 1 to enable SVC temporal*/
     uint32_t enableStereoMVC           :1;                          /**< [in]: Set to 1 to enable stereo MVC*/
-    uint32_t hierarchicalPFrames       :1;                          /**< [in]: Set to 1 to enable hierarchical PFrames */
-    uint32_t hierarchicalBFrames       :1;                          /**< [in]: Set to 1 to enable hierarchical BFrames */
+    uint32_t hierarchicalPFrames       :1;                          /**< [in]: Set to 1 to enable hierarchical P Frames */
+    uint32_t hierarchicalBFrames       :1;                          /**< [in]: Set to 1 to enable hierarchical B Frames */
     uint32_t outputBufferingPeriodSEI  :1;                          /**< [in]: Set to 1 to write SEI buffering period syntax in the bitstream */
-    uint32_t outputPictureTimingSEI    :1;                          /**< [in]: Set to 1 to write SEI picture timing syntax in the bitstream.  When set for following rateControlMode : NV_ENC_PARAMS_RC_CBR, NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ,
-                                                                               NV_ENC_PARAMS_RC_CBR_HQ, filler data is inserted if needed to achieve hrd bitrate */
+    uint32_t outputPictureTimingSEI    :1;                          /**< [in]: Set to 1 to write SEI picture timing syntax in the bitstream. */
     uint32_t outputAUD                 :1;                          /**< [in]: Set to 1 to write access unit delimiter syntax in bitstream */
     uint32_t disableSPSPPS             :1;                          /**< [in]: Set to 1 to disable writing of Sequence and Picture parameter info in bitstream */
-
-
-
     uint32_t outputFramePackingSEI     :1;                          /**< [in]: Set to 1 to enable writing of frame packing arrangement SEI messages to bitstream */
     uint32_t outputRecoveryPointSEI    :1;                          /**< [in]: Set to 1 to enable writing of recovery point SEI message */
     uint32_t enableIntraRefresh        :1;                          /**< [in]: Set to 1 to enable gradual decoder refresh or intra refresh. If the GOP structure uses B frames this will be ignored */
-    uint32_t enableConstrainedEncoding :1;                          /**< [in]: Set this to 1 to enable constrainedFrame encoding where each slice in the constarined picture is independent of other slices
+    uint32_t enableConstrainedEncoding :1;                          /**< [in]: Set this to 1 to enable constrainedFrame encoding where each slice in the constrained picture is independent of other slices.
+                                                                               Constrained encoding works only with rectangular slices.
                                                                                Check support for constrained encoding using ::NV_ENC_CAPS_SUPPORT_CONSTRAINED_ENCODING caps. */
     uint32_t repeatSPSPPS              :1;                          /**< [in]: Set to 1 to enable writing of Sequence and Picture parameter for every IDR frame */
-    uint32_t enableVFR                 :1;                          /**< [in]: Set to 1 to enable variable frame rate. */
+    uint32_t enableVFR                 :1;                          /**< [in]: Setting enableVFR=1 currently only sets the fixed_frame_rate_flag=0 in the VUI but otherwise
+                                                                               has no impact on the encoder behavior. For more details please refer to E.1 VUI syntax of H.264 standard. Note, however, that NVENC does not support VFR encoding and rate control. */
     uint32_t enableLTR                 :1;                          /**< [in]: Set to 1 to enable LTR (Long Term Reference) frame support. LTR can be used in two modes: "LTR Trust" mode and "LTR Per Picture" mode.
                                                                                LTR Trust mode: In this mode, ltrNumFrames pictures after IDR are automatically marked as LTR. This mode is enabled by setting ltrTrustMode = 1.
                                                                                                Use of LTR Trust mode is strongly discouraged as this mode may be deprecated in future.
@@ -1353,39 +1738,45 @@ typedef struct _NV_ENC_CONFIG_H264
                                                                                                      for using LTR.
                                                                                Note that LTRs are not supported if encoding session is configured with B-frames */
     uint32_t qpPrimeYZeroTransformBypassFlag :1;                    /**< [in]: To enable lossless encode set this to 1, set QP to 0 and RC_mode to NV_ENC_PARAMS_RC_CONSTQP and profile to HIGH_444_PREDICTIVE_PROFILE.
-
-
-
-
                                                                                Check support for lossless encoding using ::NV_ENC_CAPS_SUPPORT_LOSSLESS_ENCODE caps.  */
     uint32_t useConstrainedIntraPred   :1;                          /**< [in]: Set 1 to enable constrained intra prediction. */
     uint32_t enableFillerDataInsertion :1;                          /**< [in]: Set to 1 to enable insertion of filler data in the bitstream.
-                                                                               This flag will take effect only when one of the CBR rate
-                                                                               control modes (NV_ENC_PARAMS_RC_CBR, NV_ENC_PARAMS_RC_CBR_HQ,
-                                                                               NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ) is in use and both
+                                                                               This flag will take effect only when CBR rate control mode is in use and both
                                                                                NV_ENC_INITIALIZE_PARAMS::frameRateNum and
                                                                                NV_ENC_INITIALIZE_PARAMS::frameRateDen are set to non-zero
                                                                                values. Setting this field when
                                                                                NV_ENC_INITIALIZE_PARAMS::enableOutputInVidmem is also set
                                                                                is currently not supported and will make ::NvEncInitializeEncoder()
                                                                                return an error. */
-    uint32_t reservedBitFields         :14;                         /**< [in]: Reserved bitfields and must be set to 0 */
+    uint32_t disableSVCPrefixNalu      :1;                          /**< [in]: Set to 1 to disable writing of SVC Prefix NALU preceding each slice in bitstream.
+                                                                               Applicable only when temporal SVC is enabled (NV_ENC_CONFIG_H264::enableTemporalSVC = 1). */
+    uint32_t enableScalabilityInfoSEI  :1;                          /**< [in]: Set to 1 to enable writing of Scalability Information SEI message preceding each IDR picture in bitstream
+                                                                               Applicable only when temporal SVC is enabled (NV_ENC_CONFIG_H264::enableTemporalSVC = 1). */
+    uint32_t singleSliceIntraRefresh   :1;                          /**< [in]: Set to 1 to maintain single slice in frames during intra refresh.
+                                                                               Check support for single slice intra refresh using ::NV_ENC_CAPS_SINGLE_SLICE_INTRA_REFRESH caps.
+                                                                               This flag will be ignored if the value returned for ::NV_ENC_CAPS_SINGLE_SLICE_INTRA_REFRESH caps is false. */
+    uint32_t enableTimeCode            :1;                          /**< [in]: Set to 1 to enable writing of clock timestamp sets in picture timing SEI.  Note that this flag will be ignored for D3D12 interface. */
+    uint32_t reservedBitFields         :10;                         /**< [in]: Reserved bitfields and must be set to 0 */
     uint32_t level;                                                 /**< [in]: Specifies the encoding level. Client is recommended to set this to NV_ENC_LEVEL_AUTOSELECT in order to enable the NvEncodeAPI interface to select the correct level. */
     uint32_t idrPeriod;                                             /**< [in]: Specifies the IDR interval. If not set, this is made equal to gopLength in NV_ENC_CONFIG.Low latency application client can set IDR interval to NVENC_INFINITE_GOPLENGTH so that IDR frames are not inserted automatically. */
     uint32_t separateColourPlaneFlag;                               /**< [in]: Set to 1 to enable 4:4:4 separate colour planes */
-    uint32_t disableDeblockingFilterIDC;                            /**< [in]: Specifies the deblocking filter mode. Permissible value range: [0,2] */
-    uint32_t numTemporalLayers;                                     /**< [in]: Specifies max temporal layers to be used for hierarchical coding. Valid value range is [1,::NV_ENC_CAPS_NUM_MAX_TEMPORAL_LAYERS] */
+    uint32_t disableDeblockingFilterIDC;                            /**< [in]: Specifies the deblocking filter mode. Permissible value range: [0,2]. This flag corresponds
+                                                                               to the flag disable_deblocking_filter_idc specified in section 7.4.3 of H.264 specification,
+                                                                               which specifies whether the operation of the deblocking filter shall be disabled across some
+                                                                               block edges of the slice and specifies for which edges the filtering is disabled. See section
+                                                                               7.4.3 of H.264 specification for more details.*/
+    uint32_t numTemporalLayers;                                     /**< [in]: Specifies number of temporal layers to be used for hierarchical coding / temporal SVC. Valid value range is [1,::NV_ENC_CAPS_NUM_MAX_TEMPORAL_LAYERS] */
     uint32_t spsId;                                                 /**< [in]: Specifies the SPS id of the sequence header */
     uint32_t ppsId;                                                 /**< [in]: Specifies the PPS id of the picture header */
     NV_ENC_H264_ADAPTIVE_TRANSFORM_MODE adaptiveTransformMode;      /**< [in]: Specifies the AdaptiveTransform Mode. Check support for AdaptiveTransform mode using ::NV_ENC_CAPS_SUPPORT_ADAPTIVE_TRANSFORM caps. */
     NV_ENC_H264_FMO_MODE                fmoMode;                    /**< [in]: Specified the FMO Mode. Check support for FMO using ::NV_ENC_CAPS_SUPPORT_FMO caps. */
     NV_ENC_H264_BDIRECT_MODE            bdirectMode;                /**< [in]: Specifies the BDirect mode. Check support for BDirect mode using ::NV_ENC_CAPS_SUPPORT_BDIRECT_MODE caps.*/
     NV_ENC_H264_ENTROPY_CODING_MODE     entropyCodingMode;          /**< [in]: Specifies the entropy coding mode. Check support for CABAC mode using ::NV_ENC_CAPS_SUPPORT_CABAC caps. */
-    NV_ENC_STEREO_PACKING_MODE          stereoMode;                 /**< [in]: Specifies the stereo frame packing mode which is to be signalled in frame packing arrangement SEI */
+    NV_ENC_STEREO_PACKING_MODE          stereoMode;                 /**< [in]: Specifies the stereo frame packing mode which is to be signaled in frame packing arrangement SEI */
     uint32_t                            intraRefreshPeriod;         /**< [in]: Specifies the interval between successive intra refresh if enableIntrarefresh is set. Requires enableIntraRefresh to be set.
                                                                                Will be disabled if NV_ENC_CONFIG::gopLength is not set to NVENC_INFINITE_GOPLENGTH. */
     uint32_t                            intraRefreshCnt;            /**< [in]: Specifies the length of intra refresh in number of frames for periodic intra refresh. This value should be smaller than intraRefreshPeriod */
-    uint32_t                            maxNumRefFrames;            /**< [in]: Specifies the DPB size used for encoding. Setting it to 0 will let driver use the default dpb size.
+    uint32_t                            maxNumRefFrames;            /**< [in]: Specifies the DPB size used for encoding. Setting it to 0 will let driver use the default DPB size.
                                                                                The low latency application which wants to invalidate reference frame as an error resilience tool
                                                                                is recommended to use a large DPB size so that the encoder can keep old reference frames which can be used if recent
                                                                                frames are invalidated. */
@@ -1398,7 +1789,7 @@ typedef struct _NV_ENC_CONFIG_H264
                                                                                sliceMode = 1, sliceModeData specifies maximum # of bytes in each slice (except last slice)
                                                                                sliceMode = 2, sliceModeData specifies # of MB rows in each slice (except last slice)
                                                                                sliceMode = 3, sliceModeData specifies number of slices in the picture. Driver will divide picture into slices optimally */
-    NV_ENC_CONFIG_H264_VUI_PARAMETERS   h264VUIParameters;          /**< [in]: Specifies the H264 video usability info pamameters */
+    NV_ENC_CONFIG_H264_VUI_PARAMETERS   h264VUIParameters;          /**< [in]: Specifies the H264 video usability info parameters */
     uint32_t                            ltrNumFrames;               /**< [in]: Specifies the number of LTR frames. This parameter has different meaning in two LTR modes.
                                                                                In "LTR Trust" mode (ltrTrustMode = 1), encoder will mark the first ltrNumFrames base layer reference frames within each IDR interval as LTR.
                                                                                In "LTR Per Picture" mode (ltrTrustMode = 0 and ltrMarkFrame = 1), ltrNumFrames specifies maximum number of LTR frames in DPB. */
@@ -1408,13 +1799,17 @@ typedef struct _NV_ENC_CONFIG_H264
                                                                                Set to 0 when using "LTR Per Picture" mode of LTR operation. */
     uint32_t                            chromaFormatIDC;            /**< [in]: Specifies the chroma format. Should be set to 1 for yuv420 input, 3 for yuv444 input.
                                                                                Check support for YUV444 encoding using ::NV_ENC_CAPS_SUPPORT_YUV444_ENCODE caps.*/
-    uint32_t                            maxTemporalLayers;          /**< [in]: Specifies the max temporal layer used for hierarchical coding. */
+    uint32_t                            maxTemporalLayers;          /**< [in]: Specifies the max temporal layer used for temporal SVC / hierarchical coding.
+                                                                               Defaut value of this field is NV_ENC_CAPS::NV_ENC_CAPS_NUM_MAX_TEMPORAL_LAYERS. Note that the value NV_ENC_CONFIG_H264::maxNumRefFrames should
+                                                                               be greater than or equal to (NV_ENC_CONFIG_H264::maxTemporalLayers - 2) * 2, for NV_ENC_CONFIG_H264::maxTemporalLayers >= 2.*/
     NV_ENC_BFRAME_REF_MODE              useBFramesAsRef;            /**< [in]: Specifies the B-Frame as reference mode. Check support for useBFramesAsRef mode using ::NV_ENC_CAPS_SUPPORT_BFRAME_REF_MODE caps.*/
     NV_ENC_NUM_REF_FRAMES               numRefL0;                   /**< [in]: Specifies max number of reference frames in reference picture list L0, that can be used by hardware for prediction of a frame.
                                                                                Check support for numRefL0 using ::NV_ENC_CAPS_SUPPORT_MULTIPLE_REF_FRAMES caps. */
     NV_ENC_NUM_REF_FRAMES               numRefL1;                   /**< [in]: Specifies max number of reference frames in reference picture list L1, that can be used by hardware for prediction of a frame.
                                                                                Check support for numRefL1 using ::NV_ENC_CAPS_SUPPORT_MULTIPLE_REF_FRAMES caps. */
-    uint32_t                            reserved1[267];             /**< [in]: Reserved and must be set to 0 */
+    NV_ENC_BIT_DEPTH                    outputBitDepth;             /**< [in]: Specifies pixel bit depth of encoded video. Should be set to NV_ENC_BIT_DEPTH_8 for 8 bit, NV_ENC_BIT_DEPTH_10 for 10 bit. */
+    NV_ENC_BIT_DEPTH                    inputBitDepth;              /**< [in]: Specifies pixel bit depth of video input. Should be set to NV_ENC_BIT_DEPTH_8 for 8 bit input, NV_ENC_BIT_DEPTH_10 for 10 bit input. */
+    uint32_t                            reserved1[265];             /**< [in]: Reserved and must be set to 0 */
     void*                               reserved2[64];              /**< [in]: Reserved and must be set to NULL */
 } NV_ENC_CONFIG_H264;
 
@@ -1440,30 +1835,40 @@ typedef struct _NV_ENC_CONFIG_HEVC
                                                                                                      ltrTrustMode = 0 and ltrMarkFrame = 1 for the picture to be marked as LTR. This is the preferred mode
                                                                                                      for using LTR.
                                                                                Note that LTRs are not supported if encoding session is configured with B-frames */
-    uint32_t disableSPSPPS                         :1;              /**< [in]: Set 1 to disable VPS,SPS and PPS signalling in the bitstream. */
+    uint32_t disableSPSPPS                         :1;              /**< [in]: Set 1 to disable VPS, SPS and PPS signaling in the bitstream. */
     uint32_t repeatSPSPPS                          :1;              /**< [in]: Set 1 to output VPS,SPS and PPS for every IDR frame.*/
     uint32_t enableIntraRefresh                    :1;              /**< [in]: Set 1 to enable gradual decoder refresh or intra refresh. If the GOP structure uses B frames this will be ignored */
     uint32_t chromaFormatIDC                       :2;              /**< [in]: Specifies the chroma format. Should be set to 1 for yuv420 input, 3 for yuv444 input.*/
-    uint32_t pixelBitDepthMinus8                   :3;              /**< [in]: Specifies pixel bit depth minus 8. Should be set to 0 for 8 bit input, 2 for 10 bit input.*/
+    uint32_t reserved3                             :3;              /**< [in]: Reserved and must be set to 0.*/
     uint32_t enableFillerDataInsertion             :1;              /**< [in]: Set to 1 to enable insertion of filler data in the bitstream.
-                                                                               This flag will take effect only when one of the CBR rate
-                                                                               control modes (NV_ENC_PARAMS_RC_CBR, NV_ENC_PARAMS_RC_CBR_HQ,
-                                                                               NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ) is in use and both
+                                                                               This flag will take effect only when CBR rate control mode is in use and both
                                                                                NV_ENC_INITIALIZE_PARAMS::frameRateNum and
                                                                                NV_ENC_INITIALIZE_PARAMS::frameRateDen are set to non-zero
                                                                                values. Setting this field when
                                                                                NV_ENC_INITIALIZE_PARAMS::enableOutputInVidmem is also set
                                                                                is currently not supported and will make ::NvEncInitializeEncoder()
                                                                                return an error. */
-    uint32_t reserved                              :17;             /**< [in]: Reserved bitfields.*/
-    uint32_t idrPeriod;                                             /**< [in]: Specifies the IDR interval. If not set, this is made equal to gopLength in NV_ENC_CONFIG.Low latency application client can set IDR interval to NVENC_INFINITE_GOPLENGTH so that IDR frames are not inserted automatically. */
+    uint32_t enableConstrainedEncoding             :1;              /**< [in]: Set this to 1 to enable constrainedFrame encoding where each slice in the constrained picture is independent of other slices.
+                                                                               Constrained encoding works only with rectangular slices.
+                                                                               Check support for constrained encoding using ::NV_ENC_CAPS_SUPPORT_CONSTRAINED_ENCODING caps. */
+    uint32_t enableAlphaLayerEncoding              :1;              /**< [in]: Set this to 1 to enable HEVC encode with alpha layer. */
+    uint32_t singleSliceIntraRefresh               :1;              /**< [in]: Set this to 1 to maintain single slice frames during intra refresh.
+                                                                               Check support for single slice intra refresh using ::NV_ENC_CAPS_SINGLE_SLICE_INTRA_REFRESH caps.
+                                                                               This flag will be ignored if the value returned for ::NV_ENC_CAPS_SINGLE_SLICE_INTRA_REFRESH caps is false. */
+    uint32_t outputRecoveryPointSEI                :1;              /**< [in]: Set to 1 to enable writing of recovery point SEI message */
+    uint32_t outputTimeCodeSEI                     :1;              /**< [in]: Set 1 to write SEI time code syntax in the bitstream. Note that this flag will be ignored for D3D12 interface.*/
+    uint32_t reserved                              :12;             /**< [in]: Reserved bitfields.*/
+    uint32_t idrPeriod;                                             /**< [in]: Specifies the IDR interval. If not set, this is made equal to gopLength in NV_ENC_CONFIG. Low latency application client can set IDR interval to NVENC_INFINITE_GOPLENGTH so that IDR frames are not inserted automatically. */
     uint32_t intraRefreshPeriod;                                    /**< [in]: Specifies the interval between successive intra refresh if enableIntrarefresh is set. Requires enableIntraRefresh to be set.
                                                                     Will be disabled if NV_ENC_CONFIG::gopLength is not set to NVENC_INFINITE_GOPLENGTH. */
     uint32_t intraRefreshCnt;                                       /**< [in]: Specifies the length of intra refresh in number of frames for periodic intra refresh. This value should be smaller than intraRefreshPeriod */
     uint32_t maxNumRefFramesInDPB;                                  /**< [in]: Specifies the maximum number of references frames in the DPB.*/
     uint32_t ltrNumFrames;                                          /**< [in]: This parameter has different meaning in two LTR modes.
                                                                                In "LTR Trust" mode (ltrTrustMode = 1), encoder will mark the first ltrNumFrames base layer reference frames within each IDR interval as LTR.
-                                                                               In "LTR Per Picture" mode (ltrTrustMode = 0 and ltrMarkFrame = 1), ltrNumFrames specifies maximum number of LTR frames in DPB. */
+                                                                               In "LTR Per Picture" mode (ltrTrustMode = 0 and ltrMarkFrame = 1), ltrNumFrames specifies maximum number of LTR frames in DPB.
+                                                                               These ltrNumFrames acts as a guidance to the encoder and are not necessarily honored. To achieve a right balance between the encoding
+                                                                               quality and keeping LTR frames in the DPB queue, the encoder can internally limit the number of LTR frames.
+                                                                               The number of LTR frames actually used depends upon the encoding preset being used; Faster encoding presets will use fewer LTR frames.*/
     uint32_t vpsId;                                                 /**< [in]: Specifies the VPS id of the video parameter set */
     uint32_t spsId;                                                 /**< [in]: Specifies the SPS id of the sequence header */
     uint32_t ppsId;                                                 /**< [in]: Specifies the PPS id of the picture header */
@@ -1476,7 +1881,7 @@ typedef struct _NV_ENC_CONFIG_HEVC
                                                                                 sliceMode = 2, sliceModeData specifies # of CTU rows in each slice (except last slice)
                                                                                 sliceMode = 3, sliceModeData specifies number of slices in the picture. Driver will divide picture into slices optimally */
     uint32_t maxTemporalLayersMinus1;                               /**< [in]: Specifies the max temporal layer used for hierarchical coding. */
-    NV_ENC_CONFIG_HEVC_VUI_PARAMETERS   hevcVUIParameters;          /**< [in]: Specifies the HEVC video usability info pamameters */
+    NV_ENC_CONFIG_HEVC_VUI_PARAMETERS   hevcVUIParameters;          /**< [in]: Specifies the HEVC video usability info parameters */
     uint32_t ltrTrustMode;                                          /**< [in]: Specifies the LTR operating mode. See comments near NV_ENC_CONFIG_HEVC::enableLTR for description of the two modes.
                                                                                Set to 1 to use "LTR Trust" mode of LTR operation. Clients are discouraged to use "LTR Trust" mode as this mode may
                                                                                be deprecated in future releases.
@@ -1486,9 +1891,123 @@ typedef struct _NV_ENC_CONFIG_HEVC
                                                                                Check support for numRefL0 using ::NV_ENC_CAPS_SUPPORT_MULTIPLE_REF_FRAMES caps. */
     NV_ENC_NUM_REF_FRAMES               numRefL1;                   /**< [in]: Specifies max number of reference frames in reference picture list L1, that can be used by hardware for prediction of a frame.
                                                                                Check support for numRefL1 using ::NV_ENC_CAPS_SUPPORT_MULTIPLE_REF_FRAMES caps. */
-    uint32_t                            reserved1[214];             /**< [in]: Reserved and must be set to 0.*/
+    NV_ENC_TEMPORAL_FILTER_LEVEL        tfLevel;                    /**< [in]: Specifies the strength of the temporal filtering.
+                                                                               Temporal filter feature is supported only if frameIntervalP >= 5.
+                                                                               Temporal filter feature is not supported with ZeroReorderDelay/enableStereoMVC/AlphaLayerEncoding.
+                                                                               Temporal filter is recommended for natural contents. */
+    uint32_t                            disableDeblockingFilterIDC; /**< [in]: Specifies the deblocking filter mode. Permissible value range: [0,2]. This flag corresponds
+                                                                               to the flag pps_deblocking_filter_disabled_flag specified in section 7.4.3.3 of H.265 specification,
+                                                                               which specifies whether the operation of the deblocking filter shall be disabled across some
+                                                                               block edges of the slice and specifies for which edges the filtering is disabled. See section
+                                                                               7.4.3.3 of H.265 specification for more details.*/
+   NV_ENC_BIT_DEPTH                     outputBitDepth;             /**< [in]: Specifies pixel bit depth of encoded video. Should be set to NV_ENC_BIT_DEPTH_8 for 8 bit, NV_ENC_BIT_DEPTH_10 for 10 bit.
+                                                                               SW will do the bitdepth conversion internally from inputBitDepth -> outputBitDepth if bit depths differ
+                                                                               Support for 8 bit input to 10 bit encode conversion only*/
+   NV_ENC_BIT_DEPTH                     inputBitDepth;              /**< [in]: Specifies pixel bit depth of video input. Should be set to NV_ENC_BIT_DEPTH_8 for 8 bit input, NV_ENC_BIT_DEPTH_10 for 10 bit input.*/
+    uint32_t                            reserved1[210];             /**< [in]: Reserved and must be set to 0.*/
     void*                               reserved2[64];              /**< [in]: Reserved and must be set to NULL */
 } NV_ENC_CONFIG_HEVC;
+
+#define NV_MAX_TILE_COLS_AV1               64
+#define NV_MAX_TILE_ROWS_AV1               64
+
+/**
+ * \struct _NV_ENC_FILM_GRAIN_PARAMS_AV1
+ * AV1 Film Grain Parameters structure
+ */
+
+typedef struct _NV_ENC_FILM_GRAIN_PARAMS_AV1
+{
+    uint32_t applyGrain                 :1;                         /**< [in]: Set to 1 to specify film grain should be added to frame */
+    uint32_t chromaScalingFromLuma      :1;                         /**< [in]: Set to 1 to specify the chroma scaling is inferred from luma scaling */
+    uint32_t overlapFlag                :1;                         /**< [in]: Set to 1 to indicate that overlap between film grain blocks should be applied*/
+    uint32_t clipToRestrictedRange      :1;                         /**< [in]: Set to 1 to clip values to restricted (studio) range after adding film grain  */
+    uint32_t grainScalingMinus8         :2;                         /**< [in]: Represents the shift - 8 applied to the values of the chroma component */
+    uint32_t arCoeffLag                 :2;                         /**< [in]: Specifies the number of auto-regressive coefficients for luma and chroma */
+    uint32_t numYPoints                 :4;                         /**< [in]: Specifies the number of points for the piecewise linear scaling function of the luma component */
+    uint32_t numCbPoints                :4;                         /**< [in]: Specifies the number of points for the piecewise linear scaling function of the cb component */
+    uint32_t numCrPoints                :4;                         /**< [in]: Specifies the number of points for the piecewise linear scaling function of the cr component */
+    uint32_t arCoeffShiftMinus6         :2;                         /**< [in]: specifies the range of the auto-regressive coefficients */
+    uint32_t grainScaleShift            :2;                         /**< [in]: Specifies how much the Gaussian random numbers should be scaled down during the grain synthesi process  */
+    uint32_t reserved1                  :8;                         /**< [in]: Reserved bits field - should be set to 0 */
+    uint8_t  pointYValue[14];                                       /**< [in]: pointYValue[i]: x coordinate for i-th point of luma piecewise linear scaling function. Values on a scale of 0...255 */
+    uint8_t  pointYScaling[14];                                     /**< [in]: pointYScaling[i]: i-th point output value of luma piecewise linear scaling function */
+    uint8_t  pointCbValue[10];                                      /**< [in]: pointCbValue[i]: x coordinate for i-th point of cb piecewise linear scaling function. Values on a scale of 0...255 */
+    uint8_t  pointCbScaling[10];                                    /**< [in]: pointCbScaling[i]: i-th point output value of cb piecewise linear scaling function */
+    uint8_t  pointCrValue[10];                                      /**< [in]: pointCrValue[i]: x coordinate for i-th point of cr piecewise linear scaling function. Values on a scale of 0...255 */
+    uint8_t  pointCrScaling[10];                                    /**< [in]: pointCrScaling[i]: i-th point output value of cr piecewise linear scaling function */
+    uint8_t  arCoeffsYPlus128[24];                                  /**< [in]: Specifies auto-regressive coefficients used for the Y plane */
+    uint8_t  arCoeffsCbPlus128[25];                                 /**< [in]: Specifies auto-regressive coefficients used for the U plane */
+    uint8_t  arCoeffsCrPlus128[25];                                 /**< [in]: Specifies auto-regressive coefficients used for the V plane */
+    uint8_t  reserved2[2];                                          /**< [in]: Reserved bytes -  should be set to 0 */
+    uint8_t  cbMult;                                                /**< [in]: Represents a multiplier for the cb component used in derivation of the input index to the cb component scaling function */
+    uint8_t  cbLumaMult;                                            /**< [in]: represents a multiplier for the average luma component used in derivation of the input index to the cb component scaling function. */
+    uint16_t cbOffset;                                              /**< [in]: Represents an offset used in derivation of the input index to the cb component scaling function */
+    uint8_t  crMult;                                                /**< [in]: Represents a multiplier for the cr component used in derivation of the input index to the cr component scaling function */
+    uint8_t  crLumaMult;                                            /**< [in]: represents a multiplier for the average luma component used in derivation of the input index to the cr component scaling function. */
+    uint16_t crOffset;                                              /**< [in]: Represents an offset used in derivation of the input index to the cr component scaling function */
+} NV_ENC_FILM_GRAIN_PARAMS_AV1;
+
+/**
+* \struct _NV_ENC_CONFIG_AV1
+* AV1 encoder configuration parameters to be set during initialization.
+*/
+typedef struct _NV_ENC_CONFIG_AV1
+{
+    uint32_t level;                                                 /**< [in]: Specifies the level of the encoded bitstream.*/
+    uint32_t tier;                                                  /**< [in]: Specifies the level tier of the encoded bitstream.*/
+    NV_ENC_AV1_PART_SIZE minPartSize;                               /**< [in]: Specifies the minimum size of luma coding block partition.*/
+    NV_ENC_AV1_PART_SIZE maxPartSize;                               /**< [in]: Specifies the maximum size of luma coding block partition.*/
+    uint32_t outputAnnexBFormat             : 1;                    /**< [in]: Set 1 to use Annex B format for bitstream output.*/
+    uint32_t enableTimingInfo               : 1;                    /**< [in]: Set 1 to write Timing Info into sequence/frame headers */
+    uint32_t enableDecoderModelInfo         : 1;                    /**< [in]: Set 1 to write Decoder Model Info into sequence/frame headers */
+    uint32_t enableFrameIdNumbers           : 1;                    /**< [in]: Set 1 to write Frame id numbers in  bitstream */
+    uint32_t disableSeqHdr                  : 1;                    /**< [in]: Set 1 to disable Sequence Header signaling in the bitstream. */
+    uint32_t repeatSeqHdr                   : 1;                    /**< [in]: Set 1 to output Sequence Header for every Key frame.*/
+    uint32_t enableIntraRefresh             : 1;                    /**< [in]: Set 1 to enable gradual decoder refresh or intra refresh. If the GOP structure uses B frames this will be ignored */
+    uint32_t chromaFormatIDC                : 2;                    /**< [in]: Specifies the chroma format. Should be set to 1 for yuv420 input (yuv444 input currently not supported).*/
+    uint32_t enableBitstreamPadding         : 1;                    /**< [in]: Set 1 to enable bitstream padding. */
+    uint32_t enableCustomTileConfig         : 1;                    /**< [in]: Set 1 to enable custom tile configuration: numTileColumns and numTileRows must have non zero values and tileWidths and tileHeights must point to a valid address  */
+    uint32_t enableFilmGrainParams          : 1;                    /**< [in]: Set 1 to enable custom film grain parameters: filmGrainParams must point to a valid address  */
+    uint32_t reserved4                      : 6;                    /**< [in]: Reserved and must be set to 0.*/
+    uint32_t reserved                       : 14;                   /**< [in]: Reserved bitfields.*/
+    uint32_t idrPeriod;                                             /**< [in]: Specifies the IDR/Key frame interval. If not set, this is made equal to gopLength in NV_ENC_CONFIG.Low latency application client can set IDR interval to NVENC_INFINITE_GOPLENGTH so that IDR frames are not inserted automatically. */
+    uint32_t intraRefreshPeriod;                                    /**< [in]: Specifies the interval between successive intra refresh if enableIntrarefresh is set. Requires enableIntraRefresh to be set.
+                                                                               Will be disabled if NV_ENC_CONFIG::gopLength is not set to NVENC_INFINITE_GOPLENGTH. */
+    uint32_t intraRefreshCnt;                                       /**< [in]: Specifies the length of intra refresh in number of frames for periodic intra refresh. This value should be smaller than intraRefreshPeriod */
+    uint32_t maxNumRefFramesInDPB;                                  /**< [in]: Specifies the maximum number of references frames in the DPB.*/
+    uint32_t numTileColumns;                                        /**< [in]: This parameter in conjunction with the flag enableCustomTileConfig and the array tileWidths[] specifies the way in which the picture is divided into tile columns.
+                                                                               When enableCustomTileConfig == 0, the picture will be uniformly divided into numTileColumns tile columns. If numTileColumns is not a power of 2,
+                                                                               it will be rounded down to the next power of 2 value. If numTileColumns == 0, the picture will be coded with the smallest number of vertical tiles as allowed by standard.
+                                                                               When enableCustomTileConfig == 1, numTileColumns must be > 0 and <= NV_MAX_TILE_COLS_AV1 and tileWidths must point to a valid array of numTileColumns entries.
+                                                                               Entry i specifies the width in 64x64 CTU unit of tile colum i. The sum of all the entries should be equal to the picture width in 64x64 CTU units. */
+    uint32_t numTileRows;                                           /**< [in]: This parameter in conjunction with the flag enableCustomTileConfig and the array tileHeights[] specifies the way in which the picture is divided into tiles rows
+                                                                               When enableCustomTileConfig == 0, the picture will be uniformly divided into numTileRows tile rows. If numTileRows is not a power of 2,
+                                                                               it will be rounded down to the next power of 2 value. If numTileRows == 0, the picture will be coded with the smallest number of horizontal tiles as allowed by standard.
+                                                                               When enableCustomTileConfig == 1, numTileRows must be > 0 and <= NV_MAX_TILE_ROWS_AV1 and tileHeights must point to a valid array of numTileRows entries.
+                                                                               Entry i specifies the height in 64x64 CTU unit of tile row i. The sum of all the entries should be equal to the picture hieght in 64x64 CTU units. */
+    uint32_t reserved2;                                             /**< [in]: Reserved and must be set to 0.*/ 
+    uint32_t *tileWidths;                                           /**< [in]: If enableCustomTileConfig == 1, tileWidths[i] specifies the width of tile column i in 64x64 CTU unit, with 0 <= i <= numTileColumns -1. */
+    uint32_t *tileHeights;                                          /**< [in]: If enableCustomTileConfig == 1, tileHeights[i] specifies the height of tile row i in 64x64 CTU unit, with 0 <= i <= numTileRows -1. */
+    uint32_t maxTemporalLayersMinus1;                               /**< [in]: Specifies the max temporal layer used for hierarchical coding. Cannot be reconfigured and must be specified during encoder creation if temporal layer is considered. */
+    NV_ENC_VUI_COLOR_PRIMARIES colorPrimaries;                      /**< [in]: as defined in section of ISO/IEC 23091-4/ITU-T H.273 */
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC transferCharacteristics;     /**< [in]: as defined in section of ISO/IEC 23091-4/ITU-T H.273 */
+    NV_ENC_VUI_MATRIX_COEFFS matrixCoefficients;                    /**< [in]: as defined in section of ISO/IEC 23091-4/ITU-T H.273 */
+    uint32_t colorRange;                                            /**< [in]: 0: studio swing representation - 1: full swing representation */
+    uint32_t chromaSamplePosition;                                  /**< [in]: 0: unknown
+                                                                               1: Horizontally collocated with luma (0,0) sample, between two vertical samples
+                                                                               2: Co-located with luma (0,0) sample */
+    NV_ENC_BFRAME_REF_MODE useBFramesAsRef;                         /**< [in]: Specifies the B-Frame as reference mode. Check support for useBFramesAsRef mode using  ::NV_ENC_CAPS_SUPPORT_BFRAME_REF_MODE caps.*/
+    NV_ENC_FILM_GRAIN_PARAMS_AV1 *filmGrainParams;                  /**< [in]: If enableFilmGrainParams == 1, filmGrainParams must point to a valid NV_ENC_FILM_GRAIN_PARAMS_AV1 structure */
+    NV_ENC_NUM_REF_FRAMES  numFwdRefs;                              /**< [in]: Specifies max number of forward reference frame used for prediction of a frame. It must be in range 1-4 (Last, Last2, last3 and Golden). It's a suggestive value not necessarily be honored always. */
+    NV_ENC_NUM_REF_FRAMES  numBwdRefs;                              /**< [in]: Specifies max number of L1 list reference frame used for prediction of a frame. It must be in range 1-3 (Backward, Altref2, Altref). It's a suggestive value not necessarily be honored always. */
+   NV_ENC_BIT_DEPTH outputBitDepth;                                 /**< [in]: Specifies pixel bit depth of encoded video. Should be set to NV_ENC_BIT_DEPTH_8 for 8 bit, NV_ENC_BIT_DEPTH_10 for 10 bit.
+                                                                               HW will do the bitdepth conversion internally from inputBitDepth -> outputBitDepth if bit depths differ
+                                                                               Support for 8 bit input to 10 bit encode conversion only */
+   NV_ENC_BIT_DEPTH inputBitDepth;                                  /**< [in]: Specifies pixel bit depth of video input. Should be set to NV_ENC_BIT_DEPTH_8 for 8 bit input, NV_ENC_BIT_DEPTH_10 for 10 bit input. */
+    uint32_t reserved1[233];                                        /**< [in]: Reserved and must be set to 0.*/
+    void*    reserved3[62];                                         /**< [in]: Reserved and must be set to NULL */
+} NV_ENC_CONFIG_AV1;
 
 /**
  * \struct _NV_ENC_CONFIG_H264_MEONLY
@@ -1497,11 +2016,11 @@ typedef struct _NV_ENC_CONFIG_HEVC
  */
 typedef struct _NV_ENC_CONFIG_H264_MEONLY
 {
-    uint32_t disablePartition16x16 :1;                          /**< [in]: Disable MotionEstimation on 16x16 blocks*/
-    uint32_t disablePartition8x16  :1;                          /**< [in]: Disable MotionEstimation on 8x16 blocks*/
-    uint32_t disablePartition16x8  :1;                          /**< [in]: Disable MotionEstimation on 16x8 blocks*/
-    uint32_t disablePartition8x8   :1;                          /**< [in]: Disable MotionEstimation on 8x8 blocks*/
-    uint32_t disableIntraSearch    :1;                          /**< [in]: Disable Intra search during MotionEstimation*/
+    uint32_t disablePartition16x16 :1;                          /**< [in]: Disable Motion Estimation on 16x16 blocks*/
+    uint32_t disablePartition8x16  :1;                          /**< [in]: Disable Motion Estimation on 8x16 blocks*/
+    uint32_t disablePartition16x8  :1;                          /**< [in]: Disable Motion Estimation on 16x8 blocks*/
+    uint32_t disablePartition8x8   :1;                          /**< [in]: Disable Motion Estimation on 8x8 blocks*/
+    uint32_t disableIntraSearch    :1;                          /**< [in]: Disable Intra search during Motion Estimation*/
     uint32_t bStereoEnable         :1;                          /**< [in]: Enable Stereo Mode for Motion Estimation where each view is independently executed*/
     uint32_t reserved              :26;                         /**< [in]: Reserved and must be set to 0 */
     uint32_t reserved1 [255];                                   /**< [in]: Reserved and must be set to 0 */
@@ -1528,6 +2047,7 @@ typedef union _NV_ENC_CODEC_CONFIG
 {
     NV_ENC_CONFIG_H264        h264Config;                /**< [in]: Specifies the H.264-specific encoder configuration. */
     NV_ENC_CONFIG_HEVC        hevcConfig;                /**< [in]: Specifies the HEVC-specific encoder configuration. */
+    NV_ENC_CONFIG_AV1         av1Config;                 /**< [in]: Specifies the AV1-specific encoder configuration. */
     NV_ENC_CONFIG_H264_MEONLY h264MeOnlyConfig;          /**< [in]: Specifies the H.264-specific ME only encoder configuration. */
     NV_ENC_CONFIG_HEVC_MEONLY hevcMeOnlyConfig;          /**< [in]: Specifies the HEVC-specific ME only encoder configuration. */
     uint32_t                reserved[320];               /**< [in]: Reserved and must be set to 0 */
@@ -1541,7 +2061,7 @@ typedef union _NV_ENC_CODEC_CONFIG
 typedef struct _NV_ENC_CONFIG
 {
     uint32_t                        version;                                     /**< [in]: Struct version. Must be set to ::NV_ENC_CONFIG_VER. */
-    GUID                            profileGUID;                                 /**< [in]: Specifies the codec profile guid. If client specifies \p NV_ENC_CODEC_PROFILE_AUTOSELECT_GUID the NvEncodeAPI interface will select the appropriate codec profile. */
+    GUID                            profileGUID;                                 /**< [in]: Specifies the codec profile GUID. If client specifies \p NV_ENC_CODEC_PROFILE_AUTOSELECT_GUID the NvEncodeAPI interface will select the appropriate codec profile. */
     uint32_t                        gopLength;                                   /**< [in]: Specifies the number of pictures in one GOP. Low latency application client can set goplength to NVENC_INFINITE_GOPLENGTH so that keyframes are not inserted automatically. */
     int32_t                         frameIntervalP;                              /**< [in]: Specifies the GOP pattern as follows: \p frameIntervalP = 0: I, 1: IPP, 2: IBP, 3: IBBP  If goplength is set to NVENC_INFINITE_GOPLENGTH \p frameIntervalP should be set to 1. */
     uint32_t                        monoChromeEncoding;                          /**< [in]: Set this to 1 to enable monochrome encoding for this session. */
@@ -1556,8 +2076,33 @@ typedef struct _NV_ENC_CONFIG
 } NV_ENC_CONFIG;
 
 /** macro for constructing the version field of ::_NV_ENC_CONFIG */
-#define NV_ENC_CONFIG_VER (NVENCAPI_STRUCT_VERSION(7) | ( 1<<31 ))
+#define NV_ENC_CONFIG_VER (NVENCAPI_STRUCT_VERSION(9) | ( 1<<31 ))
 
+/**
+ *  Tuning information of NVENC encoding (TuningInfo is not applicable to H264 and HEVC MEOnly mode).
+ */
+typedef enum NV_ENC_TUNING_INFO
+{
+    NV_ENC_TUNING_INFO_UNDEFINED         = 0,                                     /**< Undefined tuningInfo. Invalid value for encoding. */
+    NV_ENC_TUNING_INFO_HIGH_QUALITY      = 1,                                     /**< Tune presets for latency tolerant encoding.*/
+    NV_ENC_TUNING_INFO_LOW_LATENCY       = 2,                                     /**< Tune presets for low latency streaming.*/
+    NV_ENC_TUNING_INFO_ULTRA_LOW_LATENCY = 3,                                     /**< Tune presets for ultra low latency streaming.*/
+    NV_ENC_TUNING_INFO_LOSSLESS          = 4,                                     /**< Tune presets for lossless encoding.*/
+    NV_ENC_TUNING_INFO_ULTRA_HIGH_QUALITY = 5,                                    /**< Tune presets for latency tolerant encoding for higher quality. Only supported for HEVC on Turing+ architectures */
+    NV_ENC_TUNING_INFO_COUNT                                                      /**< Count number of tuningInfos. Invalid value. */
+}NV_ENC_TUNING_INFO;
+
+/**
+ * Split Encoding Modes (Split Encoding is not applicable to H264).
+ */
+typedef enum _NV_ENC_SPLIT_ENCODE_MODE
+{
+    NV_ENC_SPLIT_AUTO_MODE               = 0,                                    /**< Default value, split frame forced mode disabled, split frame auto mode enabled */
+    NV_ENC_SPLIT_AUTO_FORCED_MODE        = 1,                                    /**< Split frame forced mode enabled with number of strips automatically selected by driver to best fit configuration */
+    NV_ENC_SPLIT_TWO_FORCED_MODE         = 2,                                    /**< Forced 2-strip split frame encoding (if NVENC number > 1, 1-strip encode otherwise) */
+    NV_ENC_SPLIT_THREE_FORCED_MODE       = 3,                                    /**< Forced 3-strip split frame encoding (if NVENC number > 2, NVENC number of strips otherwise) */
+    NV_ENC_SPLIT_DISABLE_MODE            = 15,                                   /**< Both split frame auto mode and forced mode are disabled  */
+} NV_ENC_SPLIT_ENCODE_MODE;
 
 /**
  * \struct _NV_ENC_INITIALIZE_PARAMS
@@ -1570,38 +2115,61 @@ typedef struct _NV_ENC_INITIALIZE_PARAMS
     GUID                                       presetGUID;                      /**< [in]: Specifies the preset for encoding. If the preset GUID is set then , the preset configuration will be applied before any other parameter. */
     uint32_t                                   encodeWidth;                     /**< [in]: Specifies the encode width. If not set ::NvEncInitializeEncoder() API will fail. */
     uint32_t                                   encodeHeight;                    /**< [in]: Specifies the encode height. If not set ::NvEncInitializeEncoder() API will fail. */
-    uint32_t                                   darWidth;                        /**< [in]: Specifies the display aspect ratio Width. */
-    uint32_t                                   darHeight;                       /**< [in]: Specifies the display aspect ratio height. */
+    uint32_t                                   darWidth;                        /**< [in]: Specifies the display aspect ratio width (H264/HEVC) or the render width (AV1). */
+    uint32_t                                   darHeight;                       /**< [in]: Specifies the display aspect ratio height (H264/HEVC) or the render height (AV1). */
     uint32_t                                   frameRateNum;                    /**< [in]: Specifies the numerator for frame rate used for encoding in frames per second ( Frame rate = frameRateNum / frameRateDen ). */
     uint32_t                                   frameRateDen;                    /**< [in]: Specifies the denominator for frame rate used for encoding in frames per second ( Frame rate = frameRateNum / frameRateDen ). */
     uint32_t                                   enableEncodeAsync;               /**< [in]: Set this to 1 to enable asynchronous mode and is expected to use events to get picture completion notification. */
     uint32_t                                   enablePTD;                       /**< [in]: Set this to 1 to enable the Picture Type Decision is be taken by the NvEncodeAPI interface. */
     uint32_t                                   reportSliceOffsets        :1;    /**< [in]: Set this to 1 to enable reporting slice offsets in ::_NV_ENC_LOCK_BITSTREAM. NV_ENC_INITIALIZE_PARAMS::enableEncodeAsync must be set to 0 to use this feature. Client must set this to 0 if NV_ENC_CONFIG_H264::sliceMode is 1 on Kepler GPUs */
-    uint32_t                                   enableSubFrameWrite       :1;    /**< [in]: Set this to 1 to write out available bitstream to memory at subframe intervals */
+    uint32_t                                   enableSubFrameWrite       :1;    /**< [in]: Set this to 1 to write out available bitstream to memory at subframe intervals.
+                                                                                           If enableSubFrameWrite = 1, then the hardware encoder returns data as soon as a slice (H264/HEVC) or tile (AV1) has completed encoding.
+                                                                                           This results in better encoding latency, but the downside is that the application has to keep polling via a call to nvEncLockBitstream API continuously to see if any encoded slice/tile data is available.
+                                                                                           Use this mode if you feel that the marginal reduction in latency from sub-frame encoding is worth the increase in complexity due to CPU-based polling. */
     uint32_t                                   enableExternalMEHints     :1;    /**< [in]: Set to 1 to enable external ME hints for the current frame. For NV_ENC_INITIALIZE_PARAMS::enablePTD=1 with B frames, programming L1 hints is optional for B frames since Client doesn't know internal GOP structure.
                                                                                            NV_ENC_PIC_PARAMS::meHintRefPicDist should preferably be set with enablePTD=1. */
     uint32_t                                   enableMEOnlyMode          :1;    /**< [in]: Set to 1 to enable ME Only Mode .*/
-    uint32_t                                   enableWeightedPrediction  :1;    /**< [in]: Set this to 1 to enable weighted prediction. Not supported if encode session is configured for B-Frames( 'frameIntervalP' in NV_ENC_CONFIG is greater than 1).*/
+    uint32_t                                   enableWeightedPrediction  :1;    /**< [in]: Set this to 1 to enable weighted prediction. Not supported if encode session is configured for B-Frames (i.e. NV_ENC_CONFIG::frameIntervalP > 1 or preset >=P3 when tuningInfo = ::NV_ENC_TUNING_INFO_HIGH_QUALITY or
+                                                                                           tuningInfo = ::NV_ENC_TUNING_INFO_LOSSLESS. This is because preset >=p3 internally enables B frames when tuningInfo = ::NV_ENC_TUNING_INFO_HIGH_QUALITY or ::NV_ENC_TUNING_INFO_LOSSLESS). */
+    uint32_t                                   splitEncodeMode           :4;    /**< [in]: Split Encoding mode in NVENC (Split Encoding is not applicable to H264).
+                                                                                           Not supported if any of the following features: weighted prediction, alpha layer encoding,
+                                                                                           subframe mode, output into video memory buffer, picture timing/buffering period SEI message
+                                                                                           insertion with DX12 interface are enabled in case of HEVC.
+                                                                                           For AV1, split encoding is not supported when output into video memory buffer is enabled. */
     uint32_t                                   enableOutputInVidmem      :1;    /**< [in]: Set this to 1 to enable output of NVENC in video memory buffer created by application. This feature is not supported for HEVC ME only mode. */
-    uint32_t                                   reservedBitFields         :26;   /**< [in]: Reserved bitfields and must be set to 0 */
+    uint32_t                                   enableReconFrameOutput    :1;    /**< [in]: Set this to 1 to enable reconstructed frame output. */
+    uint32_t                                   enableOutputStats         :1;    /**< [in]: Set this to 1 to enable encoded frame output stats. Client must allocate buffer of size equal to number of blocks multiplied by the size of
+                                                                                           NV_ENC_OUTPUT_STATS_BLOCK struct in system memory and assign to NV_ENC_LOCK_BITSTREAM::encodedOutputStatsPtr to receive the encoded frame output stats.*/
+    uint32_t                                   enableUniDirectionalB     :1;    /**< [in]: Set this to 1 to enable uni directional B-frame(both reference will be from past). It will give better compression
+                                                                                           efficiency for LowLatency/UltraLowLatency use case. Value of parameter is ignored when regular B frames are used. */
+    uint32_t                                   reservedBitFields         :19;   /**< [in]: Reserved bitfields and must be set to 0 */
     uint32_t                                   privDataSize;                    /**< [in]: Reserved private data buffer size and must be set to 0 */
+    uint32_t                                   reserved;                        /**< [in]: Reserved and must be set to 0 */
     void*                                      privData;                        /**< [in]: Reserved private data buffer and must be set to NULL */
     NV_ENC_CONFIG*                             encodeConfig;                    /**< [in]: Specifies the advanced codec specific structure. If client has sent a valid codec config structure, it will override parameters set by the NV_ENC_INITIALIZE_PARAMS::presetGUID parameter. If set to NULL the NvEncodeAPI interface will use the NV_ENC_INITIALIZE_PARAMS::presetGUID to set the codec specific parameters.
-                                                                                           Client can also optionally query the NvEncodeAPI interface to get codec specific parameters for a presetGUID using ::NvEncGetEncodePresetConfig() API. It can then modify (if required) some of the codec config parameters and send down a custom config structure as part of ::_NV_ENC_INITIALIZE_PARAMS.
-                                                                                           Even in this case client is recommended to pass the same preset guid it has used in ::NvEncGetEncodePresetConfig() API to query the config structure; as NV_ENC_INITIALIZE_PARAMS::presetGUID. This will not override the custom config structure but will be used to determine other Encoder HW specific parameters not exposed in the API. */
+                                                                                           Client can also optionally query the NvEncodeAPI interface to get codec specific parameters for a presetGUID using ::NvEncGetEncodePresetConfigEx() API. It can then modify (if required) some of the codec config parameters and send down a custom config structure as part of ::_NV_ENC_INITIALIZE_PARAMS.
+                                                                                           Even in this case client is recommended to pass the same preset guid it has used in ::NvEncGetEncodePresetConfigEx() API to query the config structure; as NV_ENC_INITIALIZE_PARAMS::presetGUID. This will not override the custom config structure but will be used to determine other Encoder HW specific parameters not exposed in the API. */
     uint32_t                                   maxEncodeWidth;                  /**< [in]: Maximum encode width to be used for current Encode session.
                                                                                            Client should allocate output buffers according to this dimension for dynamic resolution change. If set to 0, Encoder will not allow dynamic resolution change. */
     uint32_t                                   maxEncodeHeight;                 /**< [in]: Maximum encode height to be allowed for current Encode session.
                                                                                            Client should allocate output buffers according to this dimension for dynamic resolution change. If set to 0, Encode will not allow dynamic resolution change. */
-    NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE maxMEHintCountsPerBlock[2];      /**< [in]: If Client wants to pass external motion vectors in NV_ENC_PIC_PARAMS::meExternalHints buffer it must specify the maximum number of hint candidates per block per direction for the encode session.
+    NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE maxMEHintCountsPerBlock[2];     /**< [in]: If Client wants to pass external motion vectors in NV_ENC_PIC_PARAMS::meExternalHints buffer it must specify the maximum number of hint candidates per block per direction for the encode session.
                                                                                            The NV_ENC_INITIALIZE_PARAMS::maxMEHintCountsPerBlock[0] is for L0 predictors and NV_ENC_INITIALIZE_PARAMS::maxMEHintCountsPerBlock[1] is for L1 predictors.
                                                                                            This client must also set NV_ENC_INITIALIZE_PARAMS::enableExternalMEHints to 1. */
-    uint32_t                                   reserved [289];                  /**< [in]: Reserved and must be set to 0 */
+    NV_ENC_TUNING_INFO                         tuningInfo;                      /**< [in]: Tuning Info of NVENC encoding(TuningInfo is not applicable to H264 and HEVC meonly mode). */
+    NV_ENC_BUFFER_FORMAT                       bufferFormat;                    /**< [in]: Input buffer format. Used only when DX12 interface type is used */
+    uint32_t                                   numStateBuffers;                 /**< [in]: Number of state buffers to allocate to save encoder state. Set this to value greater than zero to enable encoding without advancing the encoder state. */
+    NV_ENC_OUTPUT_STATS_LEVEL                  outputStatsLevel;                /**< [in]: Specifies the level for encoded frame output stats, when NV_ENC_INITIALIZE_PARAMS::enableOutputStats is set to 1.
+                                                                                           Client should allocate buffer of size equal to number of blocks multiplied by the size of NV_ENC_OUTPUT_STATS_BLOCK struct
+                                                                                           if NV_ENC_INITIALIZE_PARAMS::outputStatsLevel is set to NV_ENC_OUTPUT_STATS_BLOCK or number of rows multiplied by the size of 
+                                                                                           NV_ENC_OUTPUT_STATS_ROW struct if NV_ENC_INITIALIZE_PARAMS::outputStatsLevel is set to NV_ENC_OUTPUT_STATS_ROW
+                                                                                           in system memory and assign to NV_ENC_LOCK_BITSTREAM::encodedOutputStatsPtr to receive the encoded frame output stats. */
+    uint32_t                                   reserved1 [284];                  /**< [in]: Reserved and must be set to 0 */
     void*                                      reserved2[64];                   /**< [in]: Reserved and must be set to NULL */
 } NV_ENC_INITIALIZE_PARAMS;
 
 /** macro for constructing the version field of ::_NV_ENC_INITIALIZE_PARAMS */
-#define NV_ENC_INITIALIZE_PARAMS_VER (NVENCAPI_STRUCT_VERSION(5) | ( 1<<31 ))
+#define NV_ENC_INITIALIZE_PARAMS_VER (NVENCAPI_STRUCT_VERSION(7) | ( 1<<31 ))
 
 
 /**
@@ -1611,6 +2179,7 @@ typedef struct _NV_ENC_INITIALIZE_PARAMS
 typedef struct _NV_ENC_RECONFIGURE_PARAMS
 {
     uint32_t                                    version;                        /**< [in]: Struct version. Must be set to ::NV_ENC_RECONFIGURE_PARAMS_VER. */
+    uint32_t                                    reserved;                       /**< [in]: Reserved and must be set to 0 */
     NV_ENC_INITIALIZE_PARAMS                    reInitEncodeParams;             /**< [in]: Encoder session re-initialization parameters.
                                                                                            If reInitEncodeParams.encodeConfig is NULL and
                                                                                            reInitEncodeParams.presetGUID is the same as the preset
@@ -1630,12 +2199,13 @@ typedef struct _NV_ENC_RECONFIGURE_PARAMS
                                                                                            If NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1, encoder will force the frame type to IDR */
     uint32_t                                    forceIDR                :1;     /**< [in]: Encode the current picture as an IDR picture. This flag is only valid when Picture type decision is taken by the Encoder
                                                                                            [_NV_ENC_INITIALIZE_PARAMS::enablePTD == 1]. */
-    uint32_t                                    reserved                :30;
+    uint32_t                                    reserved1                :30;
+    uint32_t                                    reserved2;                      /**< [in]: Reserved and must be set to 0 */
 
 }NV_ENC_RECONFIGURE_PARAMS;
 
 /** macro for constructing the version field of ::_NV_ENC_RECONFIGURE_PARAMS */
-#define NV_ENC_RECONFIGURE_PARAMS_VER (NVENCAPI_STRUCT_VERSION(1) | ( 1<<31 ))
+#define NV_ENC_RECONFIGURE_PARAMS_VER (NVENCAPI_STRUCT_VERSION(2) | ( 1<<31 ))
 
 /**
  * \struct _NV_ENC_PRESET_CONFIG
@@ -1644,13 +2214,14 @@ typedef struct _NV_ENC_RECONFIGURE_PARAMS
 typedef struct _NV_ENC_PRESET_CONFIG
 {
     uint32_t      version;                               /**< [in]:  Struct version. Must be set to ::NV_ENC_PRESET_CONFIG_VER. */
+    uint32_t      reserved;                              /**< [in]: Reserved and must be set to 0 */
     NV_ENC_CONFIG presetCfg;                             /**< [out]: preset config returned by the Nvidia Video Encoder interface. */
-    uint32_t      reserved1[255];                        /**< [in]: Reserved and must be set to 0 */
+    uint32_t      reserved1[256];                        /**< [in]: Reserved and must be set to 0 */
     void*         reserved2[64];                         /**< [in]: Reserved and must be set to NULL */
 }NV_ENC_PRESET_CONFIG;
 
 /** macro for constructing the version field of ::_NV_ENC_PRESET_CONFIG */
-#define NV_ENC_PRESET_CONFIG_VER (NVENCAPI_STRUCT_VERSION(4) | ( 1<<31 ))
+#define NV_ENC_PRESET_CONFIG_VER (NVENCAPI_STRUCT_VERSION(5) | ( 1<<31 ))
 
 
 /**
@@ -1728,14 +2299,15 @@ typedef struct _NV_ENC_PIC_PARAMS_H264
                                                                     sliceMode = 2, sliceModeData specifies # of MB rows in each slice (except last slice)
                                                                     sliceMode = 3, sliceModeData specifies number of slices in the picture. Driver will divide picture into slices optimally */
     uint32_t ltrMarkFrameIdx;                            /**< [in]: Specifies the long term referenceframe index to use for marking this frame as LTR.*/
-    uint32_t ltrUseFrameBitmap;                          /**< [in]: Specifies the the associated bitmap of LTR frame indices to use when encoding this frame. */
+    uint32_t ltrUseFrameBitmap;                          /**< [in]: Specifies the associated bitmap of LTR frame indices to use when encoding this frame. */
     uint32_t ltrUsageMode;                               /**< [in]: Not supported. Reserved for future use and must be set to 0. */
-    uint32_t forceIntraSliceCount;                       /**< [in]: Specfies the number of slices to be forced to Intra in the current picture.
+    uint32_t forceIntraSliceCount;                       /**< [in]: Specifies the number of slices to be forced to Intra in the current picture.
                                                                     This option along with forceIntraSliceIdx[] array needs to be used with sliceMode = 3 only */
     uint32_t *forceIntraSliceIdx;                        /**< [in]: Slice indices to be forced to intra in the current picture. Each slice index should be <= num_slices_in_picture -1. Index starts from 0 for first slice.
                                                                     The number of entries in this array should be equal to forceIntraSliceCount */
     NV_ENC_PIC_PARAMS_H264_EXT h264ExtPicParams;         /**< [in]: Specifies the H264 extension config parameters using this config. */
-    uint32_t reserved [210];                             /**< [in]: Reserved and must be set to 0. */
+    NV_ENC_TIME_CODE timeCode;                           /**< [in]: Specifies the clock timestamp sets used in picture timing SEI. Applicable only when NV_ENC_CONFIG_H264::enableTimeCode is set to 1. */
+    uint32_t reserved [202];                             /**< [in]: Reserved and must be set to 0. */
     void*    reserved2[61];                              /**< [in]: Reserved and must be set to NULL. */
 } NV_ENC_PIC_PARAMS_H264;
 
@@ -1758,6 +2330,7 @@ typedef struct _NV_ENC_PIC_PARAMS_HEVC
     uint32_t ltrMarkFrame               :1;              /**< [in]: Set to 1 if client wants to mark this frame as LTR */
     uint32_t ltrUseFrames               :1;              /**< [in]: Set to 1 if client allows encoding this frame using the LTR frames specified in ltrFrameBitmap */
     uint32_t reservedBitFields          :28;             /**< [in]: Reserved bit fields and must be set to 0 */
+    uint32_t reserved1;                                  /**< [in]: Reserved and must be set to 0. */
     uint8_t* sliceTypeData;                              /**< [in]: Array which specifies the slice type used to force intra slice for a particular slice. Currently supported only for NV_ENC_CONFIG_H264::sliceMode == 3.
                                                                     Client should allocate array of size sliceModeData where sliceModeData is specified in field of ::_NV_ENC_CONFIG_H264
                                                                     Array element with index n corresponds to nth slice. To force a particular slice to intra client should set corresponding array element to NV_ENC_SLICE_TYPE_I
@@ -1778,9 +2351,60 @@ typedef struct _NV_ENC_PIC_PARAMS_HEVC
     uint32_t seiPayloadArrayCnt;                         /**< [in]: Specifies the number of elements allocated in  seiPayloadArray array. */
     uint32_t reserved;                                   /**< [in]: Reserved and must be set to 0. */
     NV_ENC_SEI_PAYLOAD* seiPayloadArray;                 /**< [in]: Array of SEI payloads which will be inserted for this frame. */
-    uint32_t reserved2 [244];                             /**< [in]: Reserved and must be set to 0. */
-    void*    reserved3[61];                              /**< [in]: Reserved and must be set to NULL. */
+    NV_ENC_TIME_CODE timeCode;                           /**< [in]: Specifies the clock timestamp sets used in time code SEI. Applicable only when NV_ENC_CONFIG_HEVC::enableTimeCodeSEI is set to 1. */
+    uint32_t reserved2[236];                             /**< [in]: Reserved and must be set to 0. */
+    void* reserved3[61];                                 /**< [in]: Reserved and must be set to NULL. */
 } NV_ENC_PIC_PARAMS_HEVC;
+
+#define NV_ENC_AV1_OBU_PAYLOAD NV_ENC_SEI_PAYLOAD
+
+/**
+* \struct _NV_ENC_PIC_PARAMS_AV1
+* AV1 specific enc pic params. sent on a per frame basis.
+*/
+typedef struct _NV_ENC_PIC_PARAMS_AV1
+{
+    uint32_t displayPOCSyntax;                           /**< [in]: Specifies the display POC syntax This is required to be set if client is handling the picture type decision. */
+    uint32_t refPicFlag;                                 /**< [in]: Set to 1 for a reference picture. This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1. */
+    uint32_t temporalId;                                 /**< [in]: Specifies the temporal id of the picture */
+    uint32_t forceIntraRefreshWithFrameCnt;              /**< [in]: Forces an intra refresh with duration equal to intraRefreshFrameCnt.
+                                                                    forceIntraRefreshWithFrameCnt cannot be used if B frames are used in the GOP structure specified */
+    uint32_t goldenFrameFlag            : 1;             /**< [in]: Encode frame as Golden Frame. This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1. */
+    uint32_t arfFrameFlag               : 1;             /**< [in]: Encode frame as Alternate Reference Frame. This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1. */
+    uint32_t arf2FrameFlag              : 1;             /**< [in]: Encode frame as Alternate Reference 2 Frame. This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1. */
+    uint32_t bwdFrameFlag               : 1;             /**< [in]: Encode frame as Backward Reference Frame. This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1. */
+    uint32_t overlayFrameFlag           : 1;             /**< [in]: Encode frame as overlay frame. A previously encoded frame with the same displayPOCSyntax value should be present in reference frame buffer.
+                                                                    This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1. */
+    uint32_t showExistingFrameFlag      : 1;             /**< [in]: When ovelayFrameFlag is set to 1, this flag controls the value of the show_existing_frame syntax element associated with the overlay frame.
+                                                                    This flag is added to the interface as a placeholder. Its value is ignored for now and always assumed to be set to 1.
+                                                                    This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1. */
+    uint32_t errorResilientModeFlag     : 1;             /**< [in]: encode frame independently from previously encoded frames */
+
+    uint32_t tileConfigUpdate           : 1;             /**< [in]: Set to 1 if client wants to overwrite the default tile configuration with the tile parameters specified below
+                                                                    When forceIntraRefreshWithFrameCnt is set it will have priority over tileConfigUpdate setting */
+    uint32_t enableCustomTileConfig     : 1;             /**< [in]: Set 1 to enable custom tile configuration: numTileColumns and numTileRows must have non zero values and tileWidths and tileHeights must point to a valid address  */
+    uint32_t filmGrainParamsUpdate      : 1;             /**< [in]: Set to 1 if client wants to update previous film grain parameters: filmGrainParams must point to a valid address and encoder must have been configured with film grain enabled  */
+    uint32_t reservedBitFields          : 22;            /**< [in]: Reserved bitfields and must be set to 0 */
+    uint32_t numTileColumns;                             /**< [in]: This parameter in conjunction with the flag enableCustomTileConfig and the array tileWidths[] specifies the way in which the picture is divided into tile columns.
+                                                                    When enableCustomTileConfig == 0, the picture will be uniformly divided into numTileColumns tile columns. If numTileColumns is not a power of 2,
+                                                                    it will be rounded down to the next power of 2 value. If numTileColumns == 0, the picture will be coded with the smallest number of vertical tiles as allowed by standard.
+                                                                    When enableCustomTileConfig == 1, numTileColumns must be > 0 and <= NV_MAX_TILE_COLS_AV1 and tileWidths must point to a valid array of numTileColumns entries.
+                                                                    Entry i specifies the width in 64x64 CTU unit of tile colum i. The sum of all the entries should be equal to the picture width in 64x64 CTU units. */
+    uint32_t numTileRows;                                /**< [in]: This parameter in conjunction with the flag enableCustomTileConfig and the array tileHeights[] specifies the way in which the picture is divided into tiles rows
+                                                                    When enableCustomTileConfig == 0, the picture will be uniformly divided into numTileRows tile rows. If numTileRows is not a power of 2,
+                                                                    it will be rounded down to the next power of 2 value. If numTileRows == 0, the picture will be coded with the smallest number of horizontal tiles as allowed by standard.
+                                                                    When enableCustomTileConfig == 1, numTileRows must be > 0 and <= NV_MAX_TILE_ROWS_AV1 and tileHeights must point to a valid array of numTileRows entries.
+                                                                    Entry i specifies the height in 64x64 CTU unit of tile row i. The sum of all the entries should be equal to the picture hieght in 64x64 CTU units. */
+    uint32_t reserved;                                   /**< [in]: Reserved and must be set to 0. */
+    uint32_t *tileWidths;                                /**< [in]: If enableCustomTileConfig == 1, tileWidths[i] specifies the width of tile column i in 64x64 CTU unit, with 0 <= i <= numTileColumns -1. */
+    uint32_t *tileHeights;                               /**< [in]: If enableCustomTileConfig == 1, tileHeights[i] specifies the height of tile row i in 64x64 CTU unit, with 0 <= i <= numTileRows -1. */
+    uint32_t obuPayloadArrayCnt;                         /**< [in]: Specifies the number of elements allocated in  obuPayloadArray array. */
+    uint32_t reserved1;                                   /**< [in]: Reserved and must be set to 0. */
+    NV_ENC_AV1_OBU_PAYLOAD* obuPayloadArray;             /**< [in]: Array of OBU payloads which will be inserted for this frame. */
+    NV_ENC_FILM_GRAIN_PARAMS_AV1 *filmGrainParams;       /**< [in]: If filmGrainParamsUpdate == 1, filmGrainParams must point to a valid NV_ENC_FILM_GRAIN_PARAMS_AV1 structure */
+    uint32_t reserved2[246];                             /**< [in]: Reserved and must be set to 0. */
+    void*    reserved3[61];                              /**< [in]: Reserved and must be set to NULL. */
+} NV_ENC_PIC_PARAMS_AV1;
 
 /**
  * Codec specific per-picture encoding parameters.
@@ -1789,8 +2413,10 @@ typedef union _NV_ENC_CODEC_PIC_PARAMS
 {
     NV_ENC_PIC_PARAMS_H264 h264PicParams;                /**< [in]: H264 encode picture params. */
     NV_ENC_PIC_PARAMS_HEVC hevcPicParams;                /**< [in]: HEVC encode picture params. */
+    NV_ENC_PIC_PARAMS_AV1  av1PicParams;                 /**< [in]: AV1 encode picture params. */
     uint32_t               reserved[256];                /**< [in]: Reserved and must be set to 0. */
 } NV_ENC_CODEC_PIC_PARAMS;
+
 
 /**
  * \struct _NV_ENC_PIC_PARAMS
@@ -1799,12 +2425,15 @@ typedef union _NV_ENC_CODEC_PIC_PARAMS
 typedef struct _NV_ENC_PIC_PARAMS
 {
     uint32_t                                    version;                        /**< [in]: Struct version. Must be set to ::NV_ENC_PIC_PARAMS_VER. */
-    uint32_t                                    inputWidth;                     /**< [in]: Specifies the input buffer width */
-    uint32_t                                    inputHeight;                    /**< [in]: Specifies the input buffer height */
+    uint32_t                                    inputWidth;                     /**< [in]: Specifies the input frame width */
+    uint32_t                                    inputHeight;                    /**< [in]: Specifies the input frame height */
     uint32_t                                    inputPitch;                     /**< [in]: Specifies the input buffer pitch. If pitch value is not known, set this to inputWidth. */
-    uint32_t                                    encodePicFlags;                 /**< [in]: Specifies bit-wise OR`ed encode pic flags. See ::NV_ENC_PIC_FLAGS enum. */
-    uint32_t                                    frameIdx;                       /**< [in]: Specifies the frame index associated with the input frame [optional]. */
-    uint64_t                                    inputTimeStamp;                 /**< [in]: Specifies presentation timestamp associated with the input picture. */
+    uint32_t                                    encodePicFlags;                 /**< [in]: Specifies bit-wise OR of encode picture flags. See ::NV_ENC_PIC_FLAGS enum. */
+    uint32_t                                    frameIdx;                       /**< [in]: Specifies the frame index associated with the input frame. It is necessary to pass this as monotonically increasing starting 0 when lookaheadLevel, UHQ Tuning Info
+                                                                                           or encoding same frames multiple times without advancing encoder state feature are enabled */
+    uint64_t                                    inputTimeStamp;                 /**< [in]: Specifies opaque data which is associated with the encoded frame, but not actually encoded in the output bitstream.
+                                                                                           This opaque data can be used later to uniquely refer to the corresponding encoded frame. For example, it can be used
+                                                                                           for identifying the frame to be invalidated in the reference picture buffer, if lost at the client. */
     uint64_t                                    inputDuration;                  /**< [in]: Specifies duration of the input picture */
     NV_ENC_INPUT_PTR                            inputBuffer;                    /**< [in]: Specifies the input buffer pointer. Client must use a pointer obtained from ::NvEncCreateInputBuffer() or ::NvEncMapInputResource() APIs.*/
     NV_ENC_OUTPUT_PTR                           outputBitstream;                /**< [in]: Specifies the output buffer pointer.
@@ -1815,33 +2444,49 @@ typedef struct _NV_ENC_PIC_PARAMS
                                                                                            NV_ENC_ENCODE_OUT_PARAMS struct and twice the input frame size for lower resolution eg. CIF and 1.5 times the input frame size for higher resolutions. If encoded bitstream size is
                                                                                            greater than the allocated buffer size for encoded bitstream, then the output buffer will have encoded bitstream data equal to buffer size. All CUDA operations on this buffer must use
                                                                                            the default stream. */
-    void*                                       completionEvent;                /**< [in]: Specifies an event to be signalled on completion of encoding of this Frame [only if operating in Asynchronous mode]. Each output buffer should be associated with a distinct event pointer. */
+    void*                                       completionEvent;                /**< [in]: Specifies an event to be signaled on completion of encoding of this Frame [only if operating in Asynchronous mode]. Each output buffer should be associated with a distinct event pointer. */
     NV_ENC_BUFFER_FORMAT                        bufferFmt;                      /**< [in]: Specifies the input buffer format. */
     NV_ENC_PIC_STRUCT                           pictureStruct;                  /**< [in]: Specifies structure of the input picture. */
     NV_ENC_PIC_TYPE                             pictureType;                    /**< [in]: Specifies input picture type. Client required to be set explicitly by the client if the client has not set NV_ENC_INITALIZE_PARAMS::enablePTD to 1 while calling NvInitializeEncoder. */
     NV_ENC_CODEC_PIC_PARAMS                     codecPicParams;                 /**< [in]: Specifies the codec specific per-picture encoding parameters. */
-    NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE meHintCountsPerBlock[2];        /**< [in]: Specifies the number of hint candidates per block per direction for the current frame. meHintCountsPerBlock[0] is for L0 predictors and meHintCountsPerBlock[1] is for L1 predictors.
-                                                                                           The candidate count in NV_ENC_PIC_PARAMS::meHintCountsPerBlock[lx] must never exceed NV_ENC_INITIALIZE_PARAMS::maxMEHintCountsPerBlock[lx] provided during encoder intialization. */
-    NVENC_EXTERNAL_ME_HINT                     *meExternalHints;                /**< [in]: Specifies the pointer to ME external hints for the current frame. The size of ME hint buffer should be equal to number of macroblocks * the total number of candidates per macroblock.
+    NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE meHintCountsPerBlock[2];        /**< [in]: For H264 and Hevc, specifies the number of hint candidates per block per direction for the current frame. meHintCountsPerBlock[0] is for L0 predictors and meHintCountsPerBlock[1] is for L1 predictors.
+                                                                                           The candidate count in NV_ENC_PIC_PARAMS::meHintCountsPerBlock[lx] must never exceed NV_ENC_INITIALIZE_PARAMS::maxMEHintCountsPerBlock[lx] provided during encoder initialization. */
+    NVENC_EXTERNAL_ME_HINT                     *meExternalHints;                /**< [in]: For H264 and Hevc, Specifies the pointer to ME external hints for the current frame. The size of ME hint buffer should be equal to number of macroblocks * the total number of candidates per macroblock.
                                                                                            The total number of candidates per MB per direction = 1*meHintCountsPerBlock[Lx].numCandsPerBlk16x16 + 2*meHintCountsPerBlock[Lx].numCandsPerBlk16x8 + 2*meHintCountsPerBlock[Lx].numCandsPerBlk8x8
                                                                                            + 4*meHintCountsPerBlock[Lx].numCandsPerBlk8x8. For frames using bidirectional ME , the total number of candidates for single macroblock is sum of total number of candidates per MB for each direction (L0 and L1) */
-    uint32_t                                    reserved1[6];                    /**< [in]: Reserved and must be set to 0 */
-    void*                                       reserved2[2];                    /**< [in]: Reserved and must be set to NULL */
-    int8_t                                     *qpDeltaMap;                      /**< [in]: Specifies the pointer to signed byte array containing value per MB in raster scan order for the current picture, which will be interpreted depending on NV_ENC_RC_PARAMS::qpMapMode.
-                                                                                            If NV_ENC_RC_PARAMS::qpMapMode is NV_ENC_QP_MAP_DELTA, qpDeltaMap specifies QP modifier per MB. This QP modifier will be applied on top of the QP chosen by rate control.
-                                                                                            If NV_ENC_RC_PARAMS::qpMapMode is NV_ENC_QP_MAP_EMPHASIS, qpDeltaMap specifies Emphasis Level Map per MB. This level value along with QP chosen by rate control is used to
+    uint32_t                                    reserved2[7];                    /**< [in]: Reserved and must be set to 0 */
+    void*                                       reserved5[2];                    /**< [in]: Reserved and must be set to NULL */
+    int8_t                                     *qpDeltaMap;                      /**< [in]: Specifies the pointer to signed byte array containing value per MB for H264, per CTB for HEVC and per SB for AV1 in raster scan order for the current picture, which will be interpreted depending on NV_ENC_RC_PARAMS::qpMapMode.
+                                                                                            If NV_ENC_RC_PARAMS::qpMapMode is NV_ENC_QP_MAP_DELTA, qpDeltaMap specifies QP modifier per MB for H264, per CTB for HEVC and per SB for AV1. This QP modifier will be applied on top of the QP chosen by rate control.
+                                                                                            If NV_ENC_RC_PARAMS::qpMapMode is NV_ENC_QP_MAP_EMPHASIS, qpDeltaMap specifies Emphasis Level Map per MB for H264. This level value along with QP chosen by rate control is used to
                                                                                             compute the QP modifier, which in turn is applied on top of QP chosen by rate control.
                                                                                             If NV_ENC_RC_PARAMS::qpMapMode is NV_ENC_QP_MAP_DISABLED, value in qpDeltaMap will be ignored.*/
-    uint32_t                                    qpDeltaMapSize;                  /**< [in]: Specifies the size in bytes of qpDeltaMap surface allocated by client and pointed to by NV_ENC_PIC_PARAMS::qpDeltaMap. Surface (array) should be picWidthInMbs * picHeightInMbs */
+    uint32_t                                    qpDeltaMapSize;                  /**< [in]: Specifies the size in bytes of qpDeltaMap surface allocated by client and pointed to by NV_ENC_PIC_PARAMS::qpDeltaMap. Surface (array) should be picWidthInMbs * picHeightInMbs for H264, picWidthInCtbs * picHeightInCtbs for HEVC and
+                                                                                            picWidthInSbs * picHeightInSbs for AV1 */
     uint32_t                                    reservedBitFields;               /**< [in]: Reserved bitfields and must be set to 0 */
     uint16_t                                    meHintRefPicDist[2];             /**< [in]: Specifies temporal distance for reference picture (NVENC_EXTERNAL_ME_HINT::refidx = 0) used during external ME with NV_ENC_INITALIZE_PARAMS::enablePTD = 1 . meHintRefPicDist[0] is for L0 hints and meHintRefPicDist[1] is for L1 hints.
                                                                                             If not set, will internally infer distance of 1. Ignored for NV_ENC_INITALIZE_PARAMS::enablePTD = 0 */
-    uint32_t                                    reserved3[286];                  /**< [in]: Reserved and must be set to 0 */
-    void*                                       reserved4[60];                   /**< [in]: Reserved and must be set to NULL */
+     uint32_t                                    reserved4;                       /**< [in]: Reserved and must be set to 0 */
+    NV_ENC_INPUT_PTR                            alphaBuffer;                     /**< [in]: Specifies the input alpha buffer pointer. Client must use a pointer obtained from ::NvEncCreateInputBuffer() or ::NvEncMapInputResource() APIs.
+                                                                                            Applicable only when encoding hevc with alpha layer is enabled. */
+    NVENC_EXTERNAL_ME_SB_HINT                  *meExternalSbHints;               /**< [in]: For AV1,Specifies the pointer to ME external SB hints for the current frame. The size of ME hint buffer should be equal to meSbHintsCount. */
+    uint32_t                                    meSbHintsCount;                  /**< [in]: For AV1, specifies the total number of external ME SB hint candidates for the frame
+                                                                                            NV_ENC_PIC_PARAMS::meSbHintsCount must never exceed the total number of SBs in frame * the max number of candidates per SB provided during encoder initialization.
+                                                                                            The max number of candidates per SB is maxMeHintCountsPerBlock[0].numCandsPerSb + maxMeHintCountsPerBlock[1].numCandsPerSb */
+    uint32_t                                    stateBufferIdx;                  /**< [in]: Specifies the buffer index in which the encoder state will be saved for current frame encode. It must be in the 
+                                                                                            range 0 to NV_ENC_INITIALIZE_PARAMS::numStateBuffers - 1. */
+    NV_ENC_OUTPUT_PTR                           outputReconBuffer;               /**< [in]: Specifies the reconstructed frame buffer pointer to output reconstructed frame, if enabled by setting NV_ENC_INITIALIZE_PARAMS::enableReconFrameOutput.
+                                                                                            Client must allocate buffers for writing the reconstructed frames and register them with the Nvidia Video Encoder Interface with NV_ENC_REGISTER_RESOURCE::bufferUsage
+                                                                                            set to NV_ENC_OUTPUT_RECON. 
+                                                                                            Client must use the pointer obtained from ::NvEncMapInputResource() API and assign it to NV_ENC_PIC_PARAMS::outputReconBuffer.
+                                                                                            Reconstructed output will be in NV_ENC_BUFFER_FORMAT_NV12 format when chromaFormatIDC is set to 1.
+                                                                                            chromaFormatIDC = 3 is not supported. */
+    uint32_t                                    reserved3[284];                  /**< [in]: Reserved and must be set to 0 */    
+    void*                                       reserved6[57];                   /**< [in]: Reserved and must be set to NULL */
 } NV_ENC_PIC_PARAMS;
 
 /** Macro for constructing the version field of ::_NV_ENC_PIC_PARAMS */
-#define NV_ENC_PIC_PARAMS_VER (NVENCAPI_STRUCT_VERSION(4) | ( 1<<31 ))
+#define NV_ENC_PIC_PARAMS_VER (NVENCAPI_STRUCT_VERSION(7) | ( 1<<31 ))
 
 
 /**
@@ -1852,8 +2497,9 @@ typedef struct _NV_ENC_PIC_PARAMS
 typedef struct _NV_ENC_MEONLY_PARAMS
 {
     uint32_t                version;                            /**< [in]: Struct version. Must be set to NV_ENC_MEONLY_PARAMS_VER.*/
-    uint32_t                inputWidth;                         /**< [in]: Specifies the input buffer width */
-    uint32_t                inputHeight;                        /**< [in]: Specifies the input buffer height */
+    uint32_t                inputWidth;                         /**< [in]: Specifies the input frame width */
+    uint32_t                inputHeight;                        /**< [in]: Specifies the input frame height */
+    uint32_t                reserved;                           /**< [in]: Reserved and must be set to 0 */
     NV_ENC_INPUT_PTR        inputBuffer;                        /**< [in]: Specifies the input buffer pointer. Client must use a pointer obtained from NvEncCreateInputBuffer() or NvEncMapInputResource() APIs. */
     NV_ENC_INPUT_PTR        referenceFrame;                     /**< [in]: Specifies the reference frame pointer */
     NV_ENC_OUTPUT_PTR       mvBuffer;                           /**< [in]: Specifies the output buffer pointer.
@@ -1862,24 +2508,25 @@ typedef struct _NV_ENC_MEONLY_PARAMS
                                                                            If NV_ENC_INITIALIZE_PARAMS::enableOutputInVidmem is set to 1, client should allocate buffer in video memory for storing the motion vector data. The size of this buffer must
                                                                            be equal to total number of macroblocks multiplied by size of NV_ENC_H264_MV_DATA struct. Client should use a pointer obtained from ::NvEncMapInputResource() API, when mapping this
                                                                            output buffer and assign it to NV_ENC_MEONLY_PARAMS::mvBuffer. All CUDA operations on this buffer must use the default stream. */
+    uint32_t                reserved2;                          /**< [in]: Reserved and must be set to 0 */
     NV_ENC_BUFFER_FORMAT    bufferFmt;                          /**< [in]: Specifies the input buffer format. */
-    void*                   completionEvent;                    /**< [in]: Specifies an event to be signalled on completion of motion estimation
+    void*                   completionEvent;                    /**< [in]: Specifies an event to be signaled on completion of motion estimation
                                                                            of this Frame [only if operating in Asynchronous mode].
                                                                            Each output buffer should be associated with a distinct event pointer. */
-    uint32_t                viewID;                             /**< [in]: Specifies left,right viewID if NV_ENC_CONFIG_H264_MEONLY::bStereoEnable is set.
+    uint32_t                viewID;                             /**< [in]: Specifies left or right viewID if NV_ENC_CONFIG_H264_MEONLY::bStereoEnable is set.
                                                                             viewID can be 0,1 if bStereoEnable is set, 0 otherwise. */
     NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE
                             meHintCountsPerBlock[2];            /**< [in]: Specifies the number of hint candidates per block for the current frame. meHintCountsPerBlock[0] is for L0 predictors.
-                                                                            The candidate count in NV_ENC_PIC_PARAMS::meHintCountsPerBlock[lx] must never exceed NV_ENC_INITIALIZE_PARAMS::maxMEHintCountsPerBlock[lx] provided during encoder intialization. */
+                                                                            The candidate count in NV_ENC_PIC_PARAMS::meHintCountsPerBlock[lx] must never exceed NV_ENC_INITIALIZE_PARAMS::maxMEHintCountsPerBlock[lx] provided during encoder initialization. */
     NVENC_EXTERNAL_ME_HINT  *meExternalHints;                   /**< [in]: Specifies the pointer to ME external hints for the current frame. The size of ME hint buffer should be equal to number of macroblocks * the total number of candidates per macroblock.
                                                                             The total number of candidates per MB per direction = 1*meHintCountsPerBlock[Lx].numCandsPerBlk16x16 + 2*meHintCountsPerBlock[Lx].numCandsPerBlk16x8 + 2*meHintCountsPerBlock[Lx].numCandsPerBlk8x8
                                                                             + 4*meHintCountsPerBlock[Lx].numCandsPerBlk8x8. For frames using bidirectional ME , the total number of candidates for single macroblock is sum of total number of candidates per MB for each direction (L0 and L1) */
-    uint32_t                reserved1[243];                     /**< [in]: Reserved and must be set to 0 */
-    void*                   reserved2[59];                      /**< [in]: Reserved and must be set to NULL */
+    uint32_t                reserved1[241];                     /**< [in]: Reserved and must be set to 0 */
+    void*                   reserved3[59];                      /**< [in]: Reserved and must be set to NULL */
 } NV_ENC_MEONLY_PARAMS;
 
 /** NV_ENC_MEONLY_PARAMS struct version*/
-#define NV_ENC_MEONLY_PARAMS_VER NVENCAPI_STRUCT_VERSION(3)
+#define NV_ENC_MEONLY_PARAMS_VER NVENCAPI_STRUCT_VERSION(4)
 
 
 /**
@@ -1894,11 +2541,13 @@ typedef struct _NV_ENC_LOCK_BITSTREAM
     uint32_t                getRCStats        :1;        /**< [in]: If this flag is set then lockBitstream call will add additional intra-inter MB count and average MVX, MVY */
     uint32_t                reservedBitFields :29;       /**< [in]: Reserved bit fields and must be set to 0 */
     void*                   outputBitstream;             /**< [in]: Pointer to the bitstream buffer being locked. */
-    uint32_t*               sliceOffsets;                /**< [in,out]: Array which receives the slice offsets. This is not supported if NV_ENC_CONFIG_H264::sliceMode is 1 on Kepler GPUs. Array size must be equal to size of frame in MBs. */
+    uint32_t*               sliceOffsets;                /**< [in, out]: Array which receives the slice (H264/HEVC) or tile (AV1) offsets. This is not supported if NV_ENC_CONFIG_H264::sliceMode is 1 on Kepler GPUs. Array size must be equal to size of frame in MBs. */
     uint32_t                frameIdx;                    /**< [out]: Frame no. for which the bitstream is being retrieved. */
     uint32_t                hwEncodeStatus;              /**< [out]: The NvEncodeAPI interface status for the locked picture. */
-    uint32_t                numSlices;                   /**< [out]: Number of slices in the encoded picture. Will be reported only if NV_ENC_INITIALIZE_PARAMS::reportSliceOffsets set to 1. */
-    uint32_t                bitstreamSizeInBytes;        /**< [out]: Actual number of bytes generated and copied to the memory pointed by bitstreamBufferPtr. */
+    uint32_t                numSlices;                   /**< [out]: Number of slices (H264/HEVC) or tiles (AV1) in the encoded picture. Will be reported only if NV_ENC_INITIALIZE_PARAMS::reportSliceOffsets set to 1. */
+    uint32_t                bitstreamSizeInBytes;        /**< [out]: Actual number of bytes generated and copied to the memory pointed by bitstreamBufferPtr.
+                                                                     When HEVC alpha layer encoding is enabled, this field reports the total encoded size in bytes i.e it is the encoded size of the base plus the alpha layer.
+                                                                     For AV1 when enablePTD is set, this field reports the total encoded size in bytes of all the encoded frames packed into the current output surface i.e. show frame plus all preceding no-show frames */
     uint64_t                outputTimeStamp;             /**< [out]: Presentation timestamp associated with the encoded output. */
     uint64_t                outputDuration;              /**< [out]: Presentation duration associates with the encoded output. */
     void*                   bitstreamBufferPtr;          /**< [out]: Pointer to the generated output bitstream.
@@ -1910,18 +2559,22 @@ typedef struct _NV_ENC_LOCK_BITSTREAM
     uint32_t                frameSatd;                   /**< [out]: Total SATD cost for whole frame. */
     uint32_t                ltrFrameIdx;                 /**< [out]: Frame index associated with this LTR frame. */
     uint32_t                ltrFrameBitmap;              /**< [out]: Bitmap of LTR frames indices which were used for encoding this frame. Value of 0 if no LTR frames were used. */
-    uint32_t                reserved[13];                /**< [in]: Reserved and must be set to 0 */
-    uint32_t                intraMBCount;                /**< [out]: For H264, Number of Intra MBs in the encoded frame. For HEVC, Number of Intra CTBs in the encoded frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1. */
-    uint32_t                interMBCount;                /**< [out]: For H264, Number of Inter MBs in the encoded frame, includes skip MBs. For HEVC, Number of Inter CTBs in the encoded frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1. */
+    uint32_t                temporalId;                  /**< [out]: TemporalId value of the frame when using temporalSVC encoding */
+    uint32_t                intraMBCount;                /**< [out]: For H264, Number of Intra MBs in the encoded frame. For HEVC, Number of Intra CTBs in the encoded frame. For AV1, Number of Intra SBs in the encoded show frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1. */
+    uint32_t                interMBCount;                /**< [out]: For H264, Number of Inter MBs in the encoded frame, includes skip MBs. For HEVC, Number of Inter CTBs in the encoded frame. For AV1, Number of Inter SBs in the encoded show frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1. */
     int32_t                 averageMVX;                  /**< [out]: Average Motion Vector in X direction for the encoded frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1. */
     int32_t                 averageMVY;                  /**< [out]: Average Motion Vector in y direction for the encoded frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1. */
+    uint32_t                alphaLayerSizeInBytes;       /**< [out]: Number of bytes generated for the alpha layer in the encoded output. Applicable only when HEVC with alpha encoding is enabled. */
+    uint32_t                outputStatsPtrSize;          /**< [in]: Size of the buffer pointed by NV_ENC_LOCK_BITSTREAM::outputStatsPtr. */
+    uint32_t                reserved;                    /**< [in]: Reserved and must be set to 0 */
+    void*                   outputStatsPtr;              /**< [in, out]: Buffer which receives the encoded frame output stats, if NV_ENC_INITIALIZE_PARAMS::enableOutputStats is set to 1. */
+    uint32_t                frameIdxDisplay;             /**< [out]: Frame index in display order */
     uint32_t                reserved1[219];              /**< [in]: Reserved and must be set to 0 */
-    void*                   reserved2[64];               /**< [in]: Reserved and must be set to NULL */
+    void*                   reserved2[63];               /**< [in]: Reserved and must be set to NULL */
+    uint32_t                reservedInternal[8];         /**< [in]: Reserved and must be set to 0 */
 } NV_ENC_LOCK_BITSTREAM;
 
-/** Macro for constructing the version field of ::_NV_ENC_LOCK_BITSTREAM */
-#define NV_ENC_LOCK_BITSTREAM_VER NVENCAPI_STRUCT_VERSION(1)
-
+#define NV_ENC_LOCK_BITSTREAM_VER (NVENCAPI_STRUCT_VERSION(2) | ( 1<<31 ))
 
 /**
  * \struct _NV_ENC_LOCK_INPUT_BUFFER
@@ -1973,6 +2626,60 @@ typedef struct _NV_ENC_INPUT_RESOURCE_OPENGL_TEX
     uint32_t target;                                      /**< [in]: Accepted values are GL_TEXTURE_RECTANGLE and GL_TEXTURE_2D. */
 } NV_ENC_INPUT_RESOURCE_OPENGL_TEX;
 
+/** \struct NV_ENC_FENCE_POINT_D3D12
+* Fence and fence value for synchronization.
+*/
+typedef struct _NV_ENC_FENCE_POINT_D3D12
+{
+    uint32_t                version;                   /**< [in]: Struct version. Must be set to ::NV_ENC_FENCE_POINT_D3D12_VER. */
+    uint32_t                reserved;                  /**< [in]: Reserved and must be set to 0. */
+    void*                   pFence;                    /**< [in]: Pointer to ID3D12Fence. This fence object is used for synchronization. */
+    uint64_t                waitValue;                 /**< [in]: Fence value to reach or exceed before the GPU operation. */
+    uint64_t                signalValue;               /**< [in]: Fence value to set the fence to, after the GPU operation. */
+    uint32_t                bWait:1;                   /**< [in]: Wait on 'waitValue' if bWait is set to 1, before starting GPU operation. */
+    uint32_t                bSignal:1;                 /**< [in]: Signal on 'signalValue' if bSignal is set to 1, after GPU operation is complete. */
+    uint32_t                reservedBitField:30;       /**< [in]: Reserved and must be set to 0. */
+    uint32_t                reserved1[7];              /**< [in]: Reserved and must be set to 0. */
+} NV_ENC_FENCE_POINT_D3D12;
+
+#define NV_ENC_FENCE_POINT_D3D12_VER NVENCAPI_STRUCT_VERSION(1)
+
+/**
+ * \struct _NV_ENC_INPUT_RESOURCE_D3D12
+ * NV_ENC_PIC_PARAMS::inputBuffer and NV_ENC_PIC_PARAMS::alphaBuffer must be a pointer to a struct of this type,
+ * when D3D12 interface is used
+ */
+typedef struct _NV_ENC_INPUT_RESOURCE_D3D12
+{
+    uint32_t                    version;                /**< [in]: Struct version. Must be set to ::NV_ENC_INPUT_RESOURCE_D3D12_VER. */
+    uint32_t                    reserved;               /**< [in]: Reserved and must be set to 0. */
+    NV_ENC_INPUT_PTR            pInputBuffer;           /**< [in]: Specifies the input surface pointer. Client must use a pointer obtained from NvEncMapInputResource() in NV_ENC_MAP_INPUT_RESOURCE::mappedResource
+                                                                   when mapping the input surface. */
+    NV_ENC_FENCE_POINT_D3D12    inputFencePoint;        /**< [in]: Specifies the fence and corresponding fence values to do GPU wait and signal. */
+    uint32_t                    reserved1[16];          /**< [in]: Reserved and must be set to 0. */
+    void*                       reserved2[16];          /**< [in]: Reserved and must be set to NULL. */
+} NV_ENC_INPUT_RESOURCE_D3D12;
+
+#define NV_ENC_INPUT_RESOURCE_D3D12_VER NVENCAPI_STRUCT_VERSION(1)
+
+/**
+ * \struct _NV_ENC_OUTPUT_RESOURCE_D3D12
+ * NV_ENC_PIC_PARAMS::outputBitstream and NV_ENC_LOCK_BITSTREAM::outputBitstream must be a pointer to a struct of this type,
+ * when D3D12 interface is used
+ */
+typedef struct _NV_ENC_OUTPUT_RESOURCE_D3D12
+{
+    uint32_t                    version;                /**< [in]: Struct version. Must be set to ::NV_ENC_OUTPUT_RESOURCE_D3D12_VER. */
+    uint32_t                    reserved;               /**< [in]: Reserved and must be set to 0. */
+    NV_ENC_INPUT_PTR            pOutputBuffer;          /**< [in]: Specifies the output buffer pointer. Client must use a pointer obtained from NvEncMapInputResource() in NV_ENC_MAP_INPUT_RESOURCE::mappedResource
+                                                                   when mapping output bitstream buffer */
+    NV_ENC_FENCE_POINT_D3D12    outputFencePoint;       /**< [in]: Specifies the fence and corresponding fence values to do GPU wait and signal.*/
+    uint32_t                    reserved1[16];          /**< [in]: Reserved and must be set to 0. */
+    void*                       reserved2[16];          /**< [in]: Reserved and must be set to NULL. */
+} NV_ENC_OUTPUT_RESOURCE_D3D12;
+
+#define NV_ENC_OUTPUT_RESOURCE_D3D12_VER NVENCAPI_STRUCT_VERSION(1)
+
 /**
  * \struct _NV_ENC_REGISTER_RESOURCE
  * Register a resource for future use with the Nvidia Video Encoder Interface.
@@ -1985,9 +2692,9 @@ typedef struct _NV_ENC_REGISTER_RESOURCE
                                                                            ::NV_ENC_INPUT_RESOURCE_TYPE_DIRECTX,
                                                                            ::NV_ENC_INPUT_RESOURCE_TYPE_CUDADEVICEPTR,
                                                                            ::NV_ENC_INPUT_RESOURCE_TYPE_OPENGL_TEX */
-    uint32_t                    width;                          /**< [in]: Input buffer Width. */
-    uint32_t                    height;                         /**< [in]: Input buffer Height. */
-    uint32_t                    pitch;                          /**< [in]: Input buffer Pitch.
+    uint32_t                    width;                          /**< [in]: Input frame width. */
+    uint32_t                    height;                         /**< [in]: Input frame height. */
+    uint32_t                    pitch;                          /**< [in]: Input buffer pitch.
                                                                            For ::NV_ENC_INPUT_RESOURCE_TYPE_DIRECTX resources, set this to 0.
                                                                            For ::NV_ENC_INPUT_RESOURCE_TYPE_CUDADEVICEPTR resources, set this to
                                                                              the pitch as obtained from cuMemAllocPitch(), or to the width in
@@ -2004,12 +2711,23 @@ typedef struct _NV_ENC_REGISTER_RESOURCE
     NV_ENC_REGISTERED_PTR       registeredResource;             /**< [out]: Registered resource handle. This should be used in future interactions with the Nvidia Video Encoder Interface. */
     NV_ENC_BUFFER_FORMAT        bufferFormat;                   /**< [in]: Buffer format of resource to be registered. */
     NV_ENC_BUFFER_USAGE         bufferUsage;                    /**< [in]: Usage of resource to be registered. */
-    uint32_t                    reserved1[247];                 /**< [in]: Reserved and must be set to 0. */
-    void*                       reserved2[62];                  /**< [in]: Reserved and must be set to NULL. */
+    NV_ENC_FENCE_POINT_D3D12*   pInputFencePoint;               /**< [in]: Specifies the input fence and corresponding fence values to do GPU wait and signal.
+                                                                           To be used only when NV_ENC_REGISTER_RESOURCE::resourceToRegister represents D3D12 surface and
+                                                                           NV_ENC_BUFFER_USAGE::bufferUsage is NV_ENC_INPUT_IMAGE.
+                                                                           The fence NV_ENC_FENCE_POINT_D3D12::pFence and NV_ENC_FENCE_POINT_D3D12::waitValue will be used to do GPU wait
+                                                                           before starting GPU operation, if NV_ENC_FENCE_POINT_D3D12::bWait is set.
+                                                                           The fence NV_ENC_FENCE_POINT_D3D12::pFence and NV_ENC_FENCE_POINT_D3D12::signalValue will be used to do GPU signal
+                                                                           when GPU operation finishes, if NV_ENC_FENCE_POINT_D3D12::bSignal is set. */
+    uint32_t                    chromaOffset[2];                /**< [out]: Chroma offset for the reconstructed output buffer when NV_ENC_BUFFER_USAGE::bufferUsage is set 
+                                                                           to NV_ENC_OUTPUT_RECON and D3D11 interface is used. 
+                                                                           When chroma components are interleaved, 'chromaOffset[0]' will contain chroma offset. 
+                                                                           chromaOffset[1] is reserved for future use. */
+    uint32_t                    reserved1[246];                 /**< [in]: Reserved and must be set to 0. */
+    void*                       reserved2[61];                  /**< [in]: Reserved and must be set to NULL. */
 } NV_ENC_REGISTER_RESOURCE;
 
 /** Macro for constructing the version field of ::_NV_ENC_REGISTER_RESOURCE */
-#define NV_ENC_REGISTER_RESOURCE_VER NVENCAPI_STRUCT_VERSION(3)
+#define NV_ENC_REGISTER_RESOURCE_VER NVENCAPI_STRUCT_VERSION(5)
 
 /**
  * \struct _NV_ENC_STAT
@@ -2019,18 +2737,26 @@ typedef struct _NV_ENC_STAT
 {
     uint32_t            version;                         /**< [in]:  Struct version. Must be set to ::NV_ENC_STAT_VER. */
     uint32_t            reserved;                        /**< [in]:  Reserved and must be set to 0 */
-    NV_ENC_OUTPUT_PTR   outputBitStream;                 /**< [out]: Specifies the pointer to output bitstream. */
+    NV_ENC_OUTPUT_PTR   outputBitStream;                 /**< [in]: Specifies the pointer to output bitstream. */
     uint32_t            bitStreamSize;                   /**< [out]: Size of generated bitstream in bytes. */
     uint32_t            picType;                         /**< [out]: Picture type of encoded picture. See ::NV_ENC_PIC_TYPE. */
     uint32_t            lastValidByteOffset;             /**< [out]: Offset of last valid bytes of completed bitstream */
     uint32_t            sliceOffsets[16];                /**< [out]: Offsets of each slice */
     uint32_t            picIdx;                          /**< [out]: Picture number */
-    uint32_t            reserved1[233];                  /**< [in]:  Reserved and must be set to 0 */
+    uint32_t            frameAvgQP;                      /**< [out]: Average QP of the frame. */
+    uint32_t            ltrFrame          :1;            /**< [out]: Flag indicating this frame is marked as LTR frame */
+    uint32_t            reservedBitFields :31;           /**< [in]:  Reserved bit fields and must be set to 0 */
+    uint32_t            ltrFrameIdx;                     /**< [out]: Frame index associated with this LTR frame. */
+    uint32_t            intraMBCount;                    /**< [out]: For H264, Number of Intra MBs in the encoded frame. For HEVC, Number of Intra CTBs in the encoded frame. */
+    uint32_t            interMBCount;                    /**< [out]: For H264, Number of Inter MBs in the encoded frame, includes skip MBs. For HEVC, Number of Inter CTBs in the encoded frame. */
+    int32_t             averageMVX;                      /**< [out]: Average Motion Vector in X direction for the encoded frame. */
+    int32_t             averageMVY;                      /**< [out]: Average Motion Vector in y direction for the encoded frame. */
+    uint32_t            reserved1[227];                  /**< [in]:  Reserved and must be set to 0 */
     void*               reserved2[64];                   /**< [in]:  Reserved and must be set to NULL */
 } NV_ENC_STAT;
 
 /** Macro for constructing the version field of ::_NV_ENC_STAT */
-#define NV_ENC_STAT_VER NVENCAPI_STRUCT_VERSION(1)
+#define NV_ENC_STAT_VER NVENCAPI_STRUCT_VERSION(2)
 
 
 /**
@@ -2040,11 +2766,12 @@ typedef struct _NV_ENC_STAT
 typedef struct _NV_ENC_SEQUENCE_PARAM_PAYLOAD
 {
     uint32_t            version;                         /**< [in]:  Struct version. Must be set to ::NV_ENC_INITIALIZE_PARAMS_VER. */
-    uint32_t            inBufferSize;                    /**< [in]:  Specifies the size of the spsppsBuffer provied by the client */
+    uint32_t            inBufferSize;                    /**< [in]:  Specifies the size of the spsppsBuffer provided by the client */
     uint32_t            spsId;                           /**< [in]:  Specifies the SPS id to be used in sequence header. Default value is 0.  */
     uint32_t            ppsId;                           /**< [in]:  Specifies the PPS id to be used in picture header. Default value is 0.  */
-    void*               spsppsBuffer;                    /**< [in]:  Specifies bitstream header pointer of size NV_ENC_SEQUENCE_PARAM_PAYLOAD::inBufferSize. It is the client's responsibility to manage this memory. */
-    uint32_t*           outSPSPPSPayloadSize;            /**< [out]: Size of the sequence and picture header in  bytes written by the NvEncodeAPI interface to the SPSPPSBuffer. */
+    void*               spsppsBuffer;                    /**< [in]:  Specifies bitstream header pointer of size NV_ENC_SEQUENCE_PARAM_PAYLOAD::inBufferSize.
+                                                                     It is the client's responsibility to manage this memory. */
+    uint32_t*           outSPSPPSPayloadSize;            /**< [out]: Size of the sequence and picture header in bytes. */
     uint32_t            reserved [250];                  /**< [in]:  Reserved and must be set to 0 */
     void*               reserved2[64];                   /**< [in]:  Reserved and must be set to NULL */
 } NV_ENC_SEQUENCE_PARAM_PAYLOAD;
@@ -2061,12 +2788,12 @@ typedef struct _NV_ENC_EVENT_PARAMS
     uint32_t            version;                          /**< [in]: Struct version. Must be set to ::NV_ENC_EVENT_PARAMS_VER. */
     uint32_t            reserved;                         /**< [in]: Reserved and must be set to 0 */
     void*               completionEvent;                  /**< [in]: Handle to event to be registered/unregistered with the NvEncodeAPI interface. */
-    uint32_t            reserved1[253];                   /**< [in]: Reserved and must be set to 0    */
+    uint32_t            reserved1[254];                   /**< [in]: Reserved and must be set to 0    */
     void*               reserved2[64];                    /**< [in]: Reserved and must be set to NULL */
 } NV_ENC_EVENT_PARAMS;
 
 /** Macro for constructing the version field of ::_NV_ENC_EVENT_PARAMS */
-#define NV_ENC_EVENT_PARAMS_VER NVENCAPI_STRUCT_VERSION(1)
+#define NV_ENC_EVENT_PARAMS_VER NVENCAPI_STRUCT_VERSION(2)
 
 /**
  * Encoder Session Creation parameters
@@ -2108,7 +2835,7 @@ NVENCSTATUS NVENCAPI NvEncOpenEncodeSession                     (void* device, u
 /**
  * \brief Retrieves the number of supported encode GUIDs.
  *
- * The function returns the number of codec guids supported by the NvEncodeAPI
+ * The function returns the number of codec GUIDs supported by the NvEncodeAPI
  * interface.
  *
  * \param [in] encoder
@@ -2134,12 +2861,12 @@ NVENCSTATUS NVENCAPI NvEncGetEncodeGUIDCount                    (void* encoder, 
 /**
  * \brief Retrieves an array of supported encoder codec GUIDs.
  *
- * The function returns an array of codec guids supported by the NvEncodeAPI interface.
+ * The function returns an array of codec GUIDs supported by the NvEncodeAPI interface.
  * The client must allocate an array where the NvEncodeAPI interface can
- * fill the supported guids and pass the pointer in \p *GUIDs parameter.
+ * fill the supported GUIDs and pass the pointer in \p *GUIDs parameter.
  * The size of the array can be determined by using ::NvEncGetEncodeGUIDCount() API.
- * The Nvidia Encoding interface returns the number of codec guids it has actually
- * filled in the guid array in the \p GUIDCount parameter.
+ * The Nvidia Encoding interface returns the number of codec GUIDs it has actually
+ * filled in the GUID array in the \p GUIDCount parameter.
  *
  * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
@@ -2170,15 +2897,15 @@ NVENCSTATUS NVENCAPI NvEncGetEncodeGUIDs                        (void* encoder, 
  * \brief Retrieves the number of supported profile GUIDs.
  *
  * The function returns the number of profile GUIDs supported for a given codec.
- * The client must first enumerate the codec guids supported by the NvEncodeAPI
- * interface. After determining the codec guid, it can query the NvEncodeAPI
- * interface to determine the number of profile guids supported for a particular
- * codec guid.
+ * The client must first enumerate the codec GUIDs supported by the NvEncodeAPI
+ * interface. After determining the codec GUID, it can query the NvEncodeAPI
+ * interface to determine the number of profile GUIDs supported for a particular
+ * codec GUID.
  *
  * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
  * \param [in] encodeGUID
- *   The codec guid for which the profile guids are being enumerated.
+ *   The codec GUID for which the profile GUIDs are being enumerated.
  * \param [out] encodeProfileGUIDCount
  *   Number of encode profiles supported for the given encodeGUID.
  *
@@ -2200,9 +2927,9 @@ NVENCSTATUS NVENCAPI NvEncGetEncodeProfileGUIDCount                    (void* en
 /**
  * \brief Retrieves an array of supported encode profile GUIDs.
  *
- * The function returns an array of supported profile guids for a particular
- * codec guid. The client must allocate an array where the NvEncodeAPI interface
- * can populate the profile guids. The client can determine the array size using
+ * The function returns an array of supported profile GUIDs for a particular
+ * codec GUID. The client must allocate an array where the NvEncodeAPI interface
+ * can populate the profile GUIDs. The client can determine the array size using
  * ::NvEncGetEncodeProfileGUIDCount() API. The client must also validiate that the
  * NvEncodeAPI interface supports the GUID the client wants to pass as \p encodeGUID
  * parameter.
@@ -2210,7 +2937,7 @@ NVENCSTATUS NVENCAPI NvEncGetEncodeProfileGUIDCount                    (void* en
  * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
  * \param [in] encodeGUID
- *   The encode guid whose profile guids are being enumerated.
+ *   The encode GUID whose profile GUIDs are being enumerated.
  * \param [in] guidArraySize
  *   Number of GUIDs to be retrieved. Should be set to the number retrieved using
  *   ::NvEncGetEncodeProfileGUIDCount.
@@ -2332,7 +3059,7 @@ NVENCSTATUS NVENCAPI NvEncGetEncodeCaps                     (void* encoder, GUID
  * \brief Retrieves the number of supported preset GUIDs.
  *
  * The function returns the number of preset GUIDs available for a given codec.
- * The client must validate the codec guid using ::NvEncGetEncodeGUIDs() API
+ * The client must validate the codec GUID using ::NvEncGetEncodeGUIDs() API
  * before calling this function.
  *
  * \param [in] encoder
@@ -2361,11 +3088,11 @@ NVENCSTATUS NVENCAPI NvEncGetEncodePresetCount              (void* encoder, GUID
 /**
  * \brief Receives an array of supported encoder preset GUIDs.
  *
- * The function returns an array of encode preset guids available for a given codec.
- * The client can directly use one of the preset guids based upon the use case
- * or target device. The preset guid chosen can be directly used in
+ * The function returns an array of encode preset GUIDs available for a given codec.
+ * The client can directly use one of the preset GUIDs based upon the use case
+ * or target device. The preset GUID chosen can be directly used in
  * NV_ENC_INITIALIZE_PARAMS::presetGUID parameter to ::NvEncEncodePicture() API.
- * Alternately client can  also use the preset guid to retrieve the encoding config
+ * Alternately client can  also use the preset GUID to retrieve the encoding config
  * parameters being used by NvEncodeAPI interface for that given preset, using
  * ::NvEncGetEncodePresetConfig() API. It can then modify preset config parameters
  * as per its use case and send it to NvEncodeAPI interface as part of
@@ -2379,7 +3106,7 @@ NVENCSTATUS NVENCAPI NvEncGetEncodePresetCount              (void* encoder, GUID
  *   Encode GUID, corresponding to which the list of supported presets is to be
  *   retrieved.
  * \param [in] guidArraySize
- *   Size of array of preset guids passed in \p preset GUIDs
+ *   Size of array of preset GUIDs passed in \p preset GUIDs
  * \param [out] presetGUIDs
  *   Array of supported Encode preset GUIDs from the NvEncodeAPI interface
  *   to client.
@@ -2405,13 +3132,14 @@ NVENCSTATUS NVENCAPI NvEncGetEncodePresetGUIDs                  (void* encoder, 
 /**
  * \brief Returns a preset config structure supported for given preset GUID.
  *
- * The function returns a preset config structure for a given preset guid. Before
- * using this function the client must enumerate the preset guids available for
+ * The function returns a preset config structure for a given preset GUID.
+ * NvEncGetEncodePresetConfig() API is not applicable to AV1.
+ * Before using this function the client must enumerate the preset GUIDs available for
  * a given codec. The preset config structure can be modified by the client depending
  * upon its use case and can be then used to initialize the encoder using
  * ::NvEncInitializeEncoder() API. The client can use this function only if it
  * wants to modify the NvEncodeAPI preset configuration, otherwise it can
- * directly use the preset guid.
+ * directly use the preset GUID.
  *
  * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
@@ -2439,6 +3167,48 @@ NVENCSTATUS NVENCAPI NvEncGetEncodePresetGUIDs                  (void* encoder, 
  */
 NVENCSTATUS NVENCAPI NvEncGetEncodePresetConfig               (void* encoder, GUID encodeGUID, GUID  presetGUID, NV_ENC_PRESET_CONFIG* presetConfig);
 
+// NvEncGetEncodePresetConfigEx
+/**
+ * \brief Returns a preset config structure supported for given preset GUID.
+ *
+ * The function returns a preset config structure for a given preset GUID and tuning info.
+ * NvEncGetEncodePresetConfigEx() API is not applicable to H264 and HEVC meonly mode.
+ * Before using this function the client must enumerate the preset GUIDs available for
+ * a given codec. The preset config structure can be modified by the client depending
+ * upon its use case and can be then used to initialize the encoder using
+ * ::NvEncInitializeEncoder() API. The client can use this function only if it
+ * wants to modify the NvEncodeAPI preset configuration, otherwise it can
+ * directly use the preset GUID.
+ *
+ * \param [in] encoder
+ *   Pointer to the NvEncodeAPI interface.
+ * \param [in] encodeGUID
+ *   Encode GUID, corresponding to which the list of supported presets is to be
+ *   retrieved.
+ * \param [in] presetGUID
+ *   Preset GUID, corresponding to which the Encoding configurations is to be
+ *   retrieved.
+ * \param [in] tuningInfo
+ *   tuning info, corresponding to which the Encoding configurations is to be
+ *   retrieved.
+ * \param [out] presetConfig
+ *   The requested Preset Encoder Attribute set. Refer ::_NV_ENC_CONFIG for
+ *    more details.
+ *
+ * \return
+ * ::NV_ENC_SUCCESS \n
+ * ::NV_ENC_ERR_INVALID_PTR \n
+ * ::NV_ENC_ERR_INVALID_ENCODERDEVICE \n
+ * ::NV_ENC_ERR_DEVICE_NOT_EXIST \n
+ * ::NV_ENC_ERR_UNSUPPORTED_PARAM \n
+ * ::NV_ENC_ERR_OUT_OF_MEMORY \n
+ * ::NV_ENC_ERR_INVALID_PARAM \n
+ * ::NV_ENC_ERR_INVALID_VERSION \n
+ * ::NV_ENC_ERR_GENERIC \n
+ *
+ */
+NVENCSTATUS NVENCAPI NvEncGetEncodePresetConfigEx               (void* encoder, GUID encodeGUID, GUID  presetGUID, NV_ENC_TUNING_INFO tuningInfo, NV_ENC_PRESET_CONFIG* presetConfig);
+
 // NvEncInitializeEncoder
 /**
  * \brief Initialize the encoder.
@@ -2450,15 +3220,15 @@ NVENCSTATUS NVENCAPI NvEncGetEncodePresetConfig               (void* encoder, GU
  * - NV_ENC_INITIALIZE_PARAMS::encodeWidth
  * - NV_ENC_INITIALIZE_PARAMS::encodeHeight
  *
- * The client can pass a preset guid directly to the NvEncodeAPI interface using
+ * The client can pass a preset GUID directly to the NvEncodeAPI interface using
  * NV_ENC_INITIALIZE_PARAMS::presetGUID field. If the client doesn't pass
  * NV_ENC_INITIALIZE_PARAMS::encodeConfig structure, the codec specific parameters
- * will be selected based on the preset guid. The preset guid must have been
+ * will be selected based on the preset GUID. The preset GUID must have been
  * validated by the client using ::NvEncGetEncodePresetGUIDs() API.
  * If the client passes a custom ::_NV_ENC_CONFIG structure through
  * NV_ENC_INITIALIZE_PARAMS::encodeConfig , it will override the codec specific parameters
- * based on the preset guid. It is recommended that even if the client passes a custom config,
- * it should also send a preset guid. In this case, the preset guid passed by the client
+ * based on the preset GUID. It is recommended that even if the client passes a custom config,
+ * it should also send a preset GUID. In this case, the preset GUID passed by the client
  * will not override any of the custom config parameters programmed by the client,
  * it is only used as a hint by the NvEncodeAPI interface to determine certain encoder parameters
  * which are not exposed to the client.
@@ -2474,9 +3244,9 @@ NVENCSTATUS NVENCAPI NvEncGetEncodePresetConfig               (void* encoder, GU
  * The client operating in asynchronous mode must allocate completion event object
  * for each output buffer and pass the completion event object in the
  * ::NvEncEncodePicture() API. The client can create another thread and wait on
- * the event object to be signalled by NvEncodeAPI interface on completion of the
+ * the event object to be signaled by NvEncodeAPI interface on completion of the
  * encoding process for the output frame. This should unblock the main thread from
- * submitting work to the encoder. When the event is signalled the client can call
+ * submitting work to the encoder. When the event is signaled the client can call
  * NvEncodeAPI interfaces to copy the bitstream data using ::NvEncLockBitstream()
  * API. This is the preferred mode of operation.
  *
@@ -2631,7 +3401,7 @@ NVENCSTATUS NVENCAPI NvEncSetIOCudaStreams                     (void* encoder, N
  * initialized using ::NvEncInitializeEncoder() API. The minimum number of output
  * buffers allocated by the client must be at least 4 more than the number of B
  * B frames being used for encoding. The client can only access the output
- * bitsteam data by locking the \p bitstreamBuffer using the ::NvEncLockBitstream()
+ * bitstream data by locking the \p bitstreamBuffer using the ::NvEncLockBitstream()
  * function.
  *
  * \param [in] encoder
@@ -2699,7 +3469,7 @@ NVENCSTATUS NVENCAPI NvEncDestroyBitstreamBuffer                (void* encoder, 
  * - NV_ENC_PIC_PARAMS_H264::refPicFlag(H264 only)
  *
  *\par MVC Encoding:
- * For MVC encoding the client must call encode picture api for each view separately
+ * For MVC encoding the client must call encode picture API for each view separately
  * and must pass valid view id in NV_ENC_PIC_PARAMS_MVC::viewID field. Currently
  * NvEncodeAPI only support stereo MVC so client must send viewID as 0 for base
  * view and view ID as 1 for dependent view.
@@ -2717,6 +3487,10 @@ NVENCSTATUS NVENCAPI NvEncDestroyBitstreamBuffer                (void* encoder, 
  * submitted for encoding. The NvEncodeAPI interface is responsible for any
  * re-ordering required for B frames and will always ensure that encoded bitstream
  * data is written in the same order in which output buffer is submitted.
+ * The NvEncodeAPI interface may return ::NV_ENC_ERR_NEED_MORE_INPUT error code for
+ * some ::NvEncEncodePicture() API calls but the client must not treat it as a fatal error.
+ * The NvEncodeAPI interface might not be able to submit an input picture buffer for encoding
+ * immediately due to re-ordering for B frames.
  *\code
   The below example shows how  asynchronous encoding in case of 1 B frames
   ------------------------------------------------------------------------
@@ -2746,14 +3520,21 @@ NVENCSTATUS NVENCAPI NvEncDestroyBitstreamBuffer                (void* encoder, 
   (I3, O3, E3)    ---P3 Frame
 
   c) NvEncodeAPI interface will make a copy of the input buffers to its internal
-   buffersfor re-ordering. These copies are done as part of nvEncEncodePicture
+   buffers for re-ordering. These copies are done as part of nvEncEncodePicture
    function call from the client and NvEncodeAPI interface is responsible for
    synchronization of copy operation with the actual encoding operation.
    I1 --> NvI1
    I2 --> NvI2
    I3 --> NvI3
 
-  d) After returning from ::NvEncEncodePicture() call , the client must queue the output
+   d) The NvEncodeAPI encodes I1 as P frame and submits I1 to encoder HW and returns ::NV_ENC_SUCCESS.
+   The NvEncodeAPI tries to encode I2 as B frame and fails with ::NV_ENC_ERR_NEED_MORE_INPUT error code.
+   The error is not fatal and it notifies client that I2 is not submitted to encoder immediately.
+   The NvEncodeAPI encodes I3 as P frame and submits I3 for encoding which will be used as  backward
+   reference frame for I2. The NvEncodeAPI then submits I2 for encoding and returns ::NV_ENC_SUCESS.
+   Both the submission are part of the same ::NvEncEncodePicture() function call.
+
+  e) After returning from ::NvEncEncodePicture() call , the client must queue the output
    bitstream  processing work to the secondary thread. The output bitstream processing
    for asynchronous mode consist of first waiting on completion event(E1, E2..)
    and then locking the output bitstream buffer(O1, O2..) for reading the encoded
@@ -2764,32 +3545,32 @@ NVENCSTATUS NVENCAPI NvEncDestroyBitstreamBuffer                (void* encoder, 
    Note they are in the same order in which client calls ::NvEncEncodePicture() API
    in \p step a).
 
-  e) NvEncodeAPI interface  will do the re-ordering such that Encoder HW will receive
+  f) NvEncodeAPI interface  will do the re-ordering such that Encoder HW will receive
   the following encode commands:
   (NvI1, O1, E1)   ---P1 Frame
   (NvI3, O2, E2)   ---P3 Frame
   (NvI2, O3, E3)   ---B2 frame
 
-  f) After the encoding operations are completed, the events will be signalled
+  g) After the encoding operations are completed, the events will be signaled
   by NvEncodeAPI interface in the following order :
-  (O1, E1) ---P1 Frame ,output bitstream copied to O1 and event E1 signalled.
-  (O2, E2) ---P3 Frame ,output bitstream copied to O2 and event E2 signalled.
-  (O3, E3) ---B2 Frame ,output bitstream copied to O3 and event E3 signalled.
+  (O1, E1) ---P1 Frame ,output bitstream copied to O1 and event E1 signaled.
+  (O2, E2) ---P3 Frame ,output bitstream copied to O2 and event E2 signaled.
+  (O3, E3) ---B2 Frame ,output bitstream copied to O3 and event E3 signaled.
 
-  g) The client must lock the bitstream data using ::NvEncLockBitstream() API in
+  h) The client must lock the bitstream data using ::NvEncLockBitstream() API in
    the order O1,O2,O3  to read the encoded data, after waiting for the events
-   to be signalled in the same order i.e E1, E2 and E3.The output processing is
+   to be signaled in the same order i.e E1, E2 and E3.The output processing is
    done in the secondary thread in the following order:
    Waits on E1, copies encoded bitstream from O1
    Waits on E2, copies encoded bitstream from O2
    Waits on E3, copies encoded bitstream from O3
 
-  -Note the client will receive the events signalling and output buffer in the
+  -Note the client will receive the events signaling and output buffer in the
    same order in which they have submitted for encoding.
   -Note the LockBitstream will have picture type field which will notify the
    output picture type to the clients.
   -Note the input, output buffer and the output completion event are free to be
-   reused once NvEncodeAPI interfaced has signalled the event and the client has
+   reused once NvEncodeAPI interfaced has signaled the event and the client has
    copied the data from the output buffer.
 
  * \endcode
@@ -2937,6 +3718,34 @@ NVENCSTATUS NVENCAPI NvEncLockBitstream                         (void* encoder, 
  */
 NVENCSTATUS NVENCAPI NvEncUnlockBitstream                       (void* encoder, NV_ENC_OUTPUT_PTR bitstreamBuffer);
 
+// NvEncRestoreEncoderState
+/**
+ * \brief Restore state of encoder
+ *
+ * This function is used to restore the state of encoder with state saved internally in
+ * state buffer corresponding to index equal to 'NV_ENC_RESTORE_ENCODER_STATE_PARAMS::bfrIndex'. 
+ * Client can specify the state type to be updated by specifying appropriate value in
+ * 'NV_ENC_RESTORE_ENCODER_STATE_PARAMS::state'. The client must call this 
+ * function after all previous encodes have finished.
+ *
+ * \param [in] encoder
+ *   Pointer to the NvEncodeAPI interface.
+ * \param [in] restoreState
+ *   Pointer to the ::_NV_ENC_RESTORE_ENCODER_STATE_PARAMS structure
+ *
+ * \return
+ * ::NV_ENC_SUCCESS \n
+ * ::NV_ENC_ERR_INVALID_PTR \n
+ * ::NV_ENC_ERR_INVALID_ENCODERDEVICE \n
+ * ::NV_ENC_ERR_DEVICE_NOT_EXIST \n
+ * ::NV_ENC_ERR_UNSUPPORTED_PARAM \n
+ * ::NV_ENC_ERR_OUT_OF_MEMORY \n
+ * ::NV_ENC_ERR_INVALID_PARAM \n
+ * ::NV_ENC_ERR_ENCODER_NOT_INITIALIZED \n
+ * ::NV_ENC_ERR_GENERIC \n
+ *
+ */
+NVENCSTATUS NVENCAPI NvEncRestoreEncoderState                    (void* encoder, NV_ENC_RESTORE_ENCODER_STATE_PARAMS* restoreState);
 
 // NvLockInputBuffer
 /**
@@ -3008,6 +3817,8 @@ NVENCSTATUS NVENCAPI NvEncUnlockInputBuffer                     (void* encoder, 
  *
  * This function is used to retrieve the encoding statistics.
  * This API is not supported when encode device type is CUDA.
+ * Note that this API will be removed in future Video Codec SDK release.
+ * Clients should use NvEncLockBitstream() API to retrieve the encoding statistics.
  *
  * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
@@ -3065,6 +3876,44 @@ NVENCSTATUS NVENCAPI NvEncGetEncodeStats                        (void* encoder, 
  */
 NVENCSTATUS NVENCAPI NvEncGetSequenceParams                     (void* encoder, NV_ENC_SEQUENCE_PARAM_PAYLOAD* sequenceParamPayload);
 
+// NvEncGetSequenceParamEx
+/**
+ * \brief Get sequence and picture header.
+ *
+ * This function can be used to retrieve the sequence and picture header out of band, even when
+ * encoder has not been initialized using ::NvEncInitializeEncoder() function.
+ * The client must allocate the memory where the NvEncodeAPI interface can copy the bitstream
+ * header and pass the pointer to the memory in NV_ENC_SEQUENCE_PARAM_PAYLOAD::spsppsBuffer.
+ * The size of buffer is passed in the field  NV_ENC_SEQUENCE_PARAM_PAYLOAD::inBufferSize.
+ * If encoder has not been initialized using ::NvEncInitializeEncoder() function, client must
+ * send NV_ENC_INITIALIZE_PARAMS as input. The NV_ENC_INITIALIZE_PARAMS passed must be same as the
+ * one which will be used for initializing encoder using ::NvEncInitializeEncoder() function later.
+ * If encoder is already initialized using ::NvEncInitializeEncoder() function, the provided
+ * NV_ENC_INITIALIZE_PARAMS structure is ignored. The NvEncodeAPI interface will copy the bitstream
+ * header payload and returns the actual size of the bitstream header in the field
+ * NV_ENC_SEQUENCE_PARAM_PAYLOAD::outSPSPPSPayloadSize. The client must call  ::NvEncGetSequenceParamsEx()
+ * function from the same thread which is being used to call ::NvEncEncodePicture() function.
+ *
+ * \param [in] encoder
+ *   Pointer to the NvEncodeAPI interface.
+ * \param [in] encInitParams
+ *   Pointer to the _NV_ENC_INITIALIZE_PARAMS structure.
+ * \param [in,out] sequenceParamPayload
+ *   Pointer to the ::_NV_ENC_SEQUENCE_PARAM_PAYLOAD structure.
+ *
+ * \return
+ * ::NV_ENC_SUCCESS \n
+ * ::NV_ENC_ERR_INVALID_PTR \n
+ * ::NV_ENC_ERR_INVALID_ENCODERDEVICE \n
+ * ::NV_ENC_ERR_DEVICE_NOT_EXIST \n
+ * ::NV_ENC_ERR_UNSUPPORTED_PARAM \n
+ * ::NV_ENC_ERR_OUT_OF_MEMORY \n
+ * ::NV_ENC_ERR_INVALID_VERSION \n
+ * ::NV_ENC_ERR_INVALID_PARAM \n
+ * ::NV_ENC_ERR_GENERIC \n
+ *
+ */
+NVENCSTATUS NVENCAPI NvEncGetSequenceParamEx                     (void* encoder, NV_ENC_INITIALIZE_PARAMS* encInitParams, NV_ENC_SEQUENCE_PARAM_PAYLOAD* sequenceParamPayload);
 
 // NvEncRegisterAsyncEvent
 /**
@@ -3075,7 +3924,7 @@ NVENCSTATUS NVENCAPI NvEncGetSequenceParams                     (void* encoder, 
  * work in asynchronous mode. In this mode the client needs to send a completion
  * event with every output buffer. The NvEncodeAPI interface will signal the
  * completion of the encoding process using this event. Only after the event is
- * signalled the client can get the encoded data using ::NvEncLockBitstream() function.
+ * signaled the client can get the encoded data using ::NvEncLockBitstream() function.
  *
  * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
@@ -3141,6 +3990,7 @@ NVENCSTATUS NVENCAPI NvEncUnregisterAsyncEvent                  (void* encoder, 
  * also true for compute (i.e. CUDA) work, provided that the previous workload using
  * the input resource was submitted to the default stream.
  * The client should not access any input buffer while they are mapped by the encoder.
+ * For D3D12 interface type, this function does not provide synchronization guarantee.
  *
  * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
@@ -3173,7 +4023,7 @@ NVENCSTATUS NVENCAPI NvEncMapInputResource                         (void* encode
  * UnMaps an input buffer which was previously mapped using ::NvEncMapInputResource()
  * API. The mapping created using ::NvEncMapInputResource() should be invalidated
  * using this API before the external resource is destroyed by the client. The client
- * must unmap the buffer after ::NvEncLockBitstream() API returns succuessfully for encode
+ * must unmap the buffer after ::NvEncLockBitstream() API returns successfully for encode
  * work submitted using the mapped input buffer.
  *
  *
@@ -3236,7 +4086,7 @@ NVENCSTATUS NVENCAPI NvEncDestroyEncoder                        (void* encoder);
  * Invalidates reference frame based on the time stamp provided by the client.
  * The encoder marks any reference frames or any frames which have been reconstructed
  * using the corrupt frame as invalid for motion estimation and uses older reference
- * frames for motion estimation. The encoded forces the current frame to be encoded
+ * frames for motion estimation. The encoder forces the current frame to be encoded
  * as an intra frame if no reference frames are left after invalidation process.
  * This is useful for low latency application for error resiliency. The client
  * is recommended to set NV_ENC_CONFIG_H264::maxNumRefFrames to a large value so
@@ -3364,7 +4214,7 @@ NVENCSTATUS NVENCAPI NvEncUnregisterResource                    (void* encoder, 
  * Change in GOP structure.
  * Change in sync-Async mode.
  * Change in MaxWidth & MaxHeight.
- * Change in PTDmode.
+ * Change in PTD mode.
  *
  * Resolution change is possible only if maxEncodeWidth & maxEncodeHeight of NV_ENC_INITIALIZE_PARAMS
  * is set while creating encoder session.
@@ -3496,7 +4346,7 @@ NVENCSTATUS NVENCAPI NvEncRunMotionEstimationOnly               (void* encoder, 
 NVENCSTATUS NVENCAPI NvEncodeAPIGetMaxSupportedVersion          (uint32_t* version);
 
 
-// NvEncodeAPIGetLastErrorString
+// NvEncGetLastErrorString
 /**
  * \brief Get the description of the last error reported by the API.
  *
@@ -3511,6 +4361,32 @@ NVENCSTATUS NVENCAPI NvEncodeAPIGetMaxSupportedVersion          (uint32_t* versi
  */
 const char * NVENCAPI NvEncGetLastErrorString          (void* encoder);
 
+// NvEncLookaheadPicture
+/**
+ * \brief Submit an input picture for lookahead.
+ *
+ * This function can be used by clients to submit input frame for lookahead. Client could call this function 
+ * NV_ENC_INITIALIZE_PARAMS::lookaheadDepth plus one number of frames, before calling NvEncEncodePicture() for the first frame.
+ *
+ * \param [in] encoder
+ *   Pointer to the NvEncodeAPI interface.
+ * \param [in] lookaheadParams
+ *   Pointer to the ::_NV_ENC_LOOKAHEAD_PIC_PARAMS structure.
+ *
+ * \return
+ * ::NV_ENC_SUCCESS \n
+ * ::NV_ENC_NEED_MORE_INPUT \n  should we return this error is lookahead queue is not full? 
+ * ::NV_ENC_ERR_INVALID_PTR \n
+ * ::NV_ENC_ERR_ENCODER_NOT_INITIALIZED \n
+ * ::NV_ENC_ERR_GENERIC \n
+ * ::NV_ENC_ERR_INVALID_ENCODERDEVICE \n
+ * ::NV_ENC_ERR_DEVICE_NOT_EXIST \n
+ * ::NV_ENC_ERR_UNSUPPORTED_PARAM \n
+ * ::NV_ENC_ERR_OUT_OF_MEMORY \n
+ * ::NV_ENC_ERR_INVALID_PARAM \n
+ * ::NV_ENC_ERR_INVALID_VERSION \n
+ */
+NVENCSTATUS NVENCAPI NvEncLookaheadPicture          (void* encoder, NV_ENC_LOOKAHEAD_PIC_PARAMS *lookaheadParamas);
 
 /// \cond API PFN
 /*
@@ -3527,6 +4403,7 @@ typedef NVENCSTATUS (NVENCAPI* PNVENCGETENCODECAPS)             (void* encoder, 
 typedef NVENCSTATUS (NVENCAPI* PNVENCGETENCODEPRESETCOUNT)      (void* encoder, GUID encodeGUID, uint32_t* encodePresetGUIDCount);
 typedef NVENCSTATUS (NVENCAPI* PNVENCGETENCODEPRESETGUIDS)      (void* encoder, GUID encodeGUID, GUID* presetGUIDs, uint32_t guidArraySize, uint32_t* encodePresetGUIDCount);
 typedef NVENCSTATUS (NVENCAPI* PNVENCGETENCODEPRESETCONFIG)     (void* encoder, GUID encodeGUID, GUID  presetGUID, NV_ENC_PRESET_CONFIG* presetConfig);
+typedef NVENCSTATUS (NVENCAPI* PNVENCGETENCODEPRESETCONFIGEX)   (void* encoder, GUID encodeGUID, GUID  presetGUID, NV_ENC_TUNING_INFO tuningInfo, NV_ENC_PRESET_CONFIG* presetConfig);
 typedef NVENCSTATUS (NVENCAPI* PNVENCINITIALIZEENCODER)         (void* encoder, NV_ENC_INITIALIZE_PARAMS* createEncodeParams);
 typedef NVENCSTATUS (NVENCAPI* PNVENCCREATEINPUTBUFFER)         (void* encoder, NV_ENC_CREATE_INPUT_BUFFER* createInputBufferParams);
 typedef NVENCSTATUS (NVENCAPI* PNVENCDESTROYINPUTBUFFER)        (void* encoder, NV_ENC_INPUT_PTR inputBuffer);
@@ -3555,6 +4432,9 @@ typedef NVENCSTATUS (NVENCAPI* PNVENCDESTROYMVBUFFER)           (void* encoder, 
 typedef NVENCSTATUS (NVENCAPI* PNVENCRUNMOTIONESTIMATIONONLY)   (void* encoder, NV_ENC_MEONLY_PARAMS* meOnlyParams);
 typedef const char * (NVENCAPI* PNVENCGETLASTERROR)             (void* encoder);
 typedef NVENCSTATUS (NVENCAPI* PNVENCSETIOCUDASTREAMS)          (void* encoder, NV_ENC_CUSTREAM_PTR inputStream, NV_ENC_CUSTREAM_PTR outputStream);
+typedef NVENCSTATUS (NVENCAPI* PNVENCGETSEQUENCEPARAMEX)        (void* encoder, NV_ENC_INITIALIZE_PARAMS* encInitParams, NV_ENC_SEQUENCE_PARAM_PAYLOAD* sequenceParamPayload);
+typedef NVENCSTATUS (NVENCAPI* PNVENCRESTOREENCODERSTATE)       (void* encoder, NV_ENC_RESTORE_ENCODER_STATE_PARAMS* restoreState);
+typedef NVENCSTATUS (NVENCAPI* PNVENCLOOKAHEADPICTURE)          (void* encoder, NV_ENC_LOOKAHEAD_PIC_PARAMS* lookaheadParams);
 
 
 /// \endcond
@@ -3609,7 +4489,11 @@ typedef struct _NV_ENCODE_API_FUNCTION_LIST
     PNVENCRUNMOTIONESTIMATIONONLY   nvEncRunMotionEstimationOnly;      /**< [out]: Client should access ::NvEncRunMotionEstimationOnly API through this pointer.    */
     PNVENCGETLASTERROR              nvEncGetLastErrorString;           /**< [out]: Client should access ::nvEncGetLastErrorString API through this pointer.         */
     PNVENCSETIOCUDASTREAMS          nvEncSetIOCudaStreams;             /**< [out]: Client should access ::nvEncSetIOCudaStreams API through this pointer.           */
-    void*                           reserved2[279];                    /**< [in]:  Reserved and must be set to NULL                                                 */
+    PNVENCGETENCODEPRESETCONFIGEX   nvEncGetEncodePresetConfigEx;      /**< [out]: Client should access ::NvEncGetEncodePresetConfigEx() API through this pointer.  */
+    PNVENCGETSEQUENCEPARAMEX        nvEncGetSequenceParamEx;           /**< [out]: Client should access ::NvEncGetSequenceParamEx() API through this pointer.       */
+    PNVENCRESTOREENCODERSTATE       nvEncRestoreEncoderState;          /**< [out]: Client should access ::NvEncRestoreEncoderState() API through this pointer.      */
+    PNVENCLOOKAHEADPICTURE          nvEncLookaheadPicture;             /**< [out]: Client should access ::NvEncLookaheadPicture() API through this pointer.         */
+    void*                           reserved2[275];                    /**< [in]:  Reserved and must be set to NULL                                                 */
 } NV_ENCODE_API_FUNCTION_LIST;
 
 /** Macro for constructing the version field of ::_NV_ENCODEAPI_FUNCTION_LIST. */

--- a/src/NvEncSharp/Enums.cs
+++ b/src/NvEncSharp/Enums.cs
@@ -29,12 +29,41 @@ namespace Lennox.NvEncSharp
         Vbr = 0x1,
         /// <summary>NV_ENC_PARAMS_RC_CBR: Constant bitrate mode</summary>
         Cbr = 0x2,
-        /// <summary>NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ: low-delay CBR, high quality</summary>
-        CbrLowdelayHq = 0x8,
-        /// <summary>NV_ENC_PARAMS_RC_CBR_HQ: CBR, high quality (slower)</summary>
-        CbrHq = 0x10,
-        /// <summary>NV_ENC_PARAMS_RC_VBR_HQ: VBR, high quality (slower)</summary>
-        VbrHq = 0x20,
+    }
+
+    /// <summary>NV_ENC_MULTI_PASS</summary>
+    public enum NvEncMultiPass
+    {
+        /// <summary>NV_ENC_MULTI_PASS_DISABLED: Single Pass</summary>
+        Disabled = 0x0,
+        /// <summary>NV_ENC_TWO_PASS_QUARTER_RESOLUTION: Two Pass encoding is enabled where first Pass is quarter resolution</summary>
+        NvEncTwoPassQuarterResolution = 0x1,
+        /// <summary>NV_ENC_TWO_PASS_FULL_RESOLUTION: Two Pass encoding is enabled where first Pass is full resolution</summary>
+        NvEncTwoPassFullResolution = 0x2,
+    }
+
+    /// <summary>NV_ENC_STATE_RESTORE_TYPE</summary>
+    public enum NvEncStateRestoreType
+    {
+        /// <summary>NV_ENC_STATE_RESTORE_FULL: Restore full encoder state</summary>
+        Full = 0x01,
+        /// <summary>NV_ENC_STATE_RESTORE_RATE_CONTROL: Restore only rate control state</summary>
+        RateControl = 0x02,
+        /// <summary>NV_ENC_STATE_RESTORE_ENCODE: Restore full encoder state except for rate control state</summary>
+        Encode = 0x03,
+    }
+
+    /// <summary>NV_ENC_OUTPUT_STATS_LEVEL</summary>
+    public enum NvEncOutputStatsLevel
+    {
+        /// <summary>NV_ENC_OUTPUT_STATS_NONE: No output stats</summary>
+        None = 0,
+        /// <summary>NV_ENC_OUTPUT_STATS_BLOCK_LEVEL: Output stats for every block. 
+        ///  Block represents a CTB for HEVC, macroblock for H.264, super block for AV1</summary>
+        BlockLevel = 1,
+        /// <summary>NV_ENC_OUTPUT_STATS_ROW_LEVEL: Output stats for every row. 
+        ///  Row represents a CTB row for HEVC, macroblock row for H.264, super block row for AV1</summary>
+        RowLevel = 2,
     }
 
     /// <summary>NV_ENC_EMPHASIS_MAP_LEVEL</summary>
@@ -59,7 +88,7 @@ namespace Lennox.NvEncSharp
     {
         /// <summary>NV_ENC_QP_MAP_DISABLED: Value in NV_ENC_PIC_PARAMS::qpDeltaMap have no effect.</summary>
         Disabled = 0x0,
-        /// <summary>NV_ENC_QP_MAP_EMPHASIS: Value in NV_ENC_PIC_PARAMS::qpDeltaMap will be treated as Empasis level. Currently this is only supported for H264</summary>
+        /// <summary>NV_ENC_QP_MAP_EMPHASIS: Value in NV_ENC_PIC_PARAMS::qpDeltaMap will be treated as Emphasis level. Currently this is only supported for H264</summary>
         Emphasis = 0x1,
         /// <summary>NV_ENC_QP_MAP_DELTA: Value in NV_ENC_PIC_PARAMS::qpDeltaMap will be treated as QP delta map.</summary>
         Delta = 0x2,
@@ -76,6 +105,21 @@ namespace Lennox.NvEncSharp
         FieldTopBottom = 0x02,
         /// <summary>NV_ENC_PIC_STRUCT_FIELD_BOTTOM_TOP: Field encoding bottom field first</summary>
         FieldBottomTop = 0x03,
+    }
+
+    /// <summary>NV_ENC_DISPLAY_PIC_STRUCT</summary>
+    public enum NvEncDisplayPicStruct
+    {
+        /// <summary>NV_ENC_PIC_STRUCT_DISPLAY_FRAME: Field encoding top field first</summary>
+        NvEncPicStructDisplayFrame = 0x00,
+        /// <summary>NV_ENC_PIC_STRUCT_DISPLAY_FIELD_TOP_BOTTOM: Field encoding top field first</summary>
+        NvEncPicStructDisplayFieldTopBottom = 0x01,
+        /// <summary>NV_ENC_PIC_STRUCT_DISPLAY_FIELD_BOTTOM_TOP: Field encoding bottom field first</summary>
+        NvEncPicStructDisplayFieldBottomTop = 0x02,
+        /// <summary>NV_ENC_PIC_STRUCT_DISPLAY_FRAME_DOUBLING: Frame doubling</summary>
+        NvEncPicStructDisplayFrameDoubling = 0x03,
+        /// <summary>NV_ENC_PIC_STRUCT_DISPLAY_FRAME_TRIPLING: Field tripling</summary>
+        NvEncPicStructDisplayFrameTripling = 0x04,
     }
 
     /// <summary>NV_ENC_PIC_TYPE</summary>
@@ -97,6 +141,8 @@ namespace Lennox.NvEncSharp
         IntraRefresh = 0x06,
         /// <summary>NV_ENC_PIC_TYPE_NONREF_P: Non reference P picture</summary>
         NonrefP = 0x07,
+        /// <summary>NV_ENC_PIC_TYPE_SWITCH: Switch frame (AV1 only)</summary>
+        Switch = 0x08,
         /// <summary>NV_ENC_PIC_TYPE_UNKNOWN: Picture type unknown</summary>
         Unknown = 0xFF,
     }
@@ -104,13 +150,13 @@ namespace Lennox.NvEncSharp
     /// <summary>NV_ENC_MV_PRECISION</summary>
     public enum NvEncMvPrecision
     {
-        /// <summary>NV_ENC_MV_PRECISION_DEFAULT: Driver selects QuarterPel motion vector precision by default</summary>
+        /// <summary>NV_ENC_MV_PRECISION_DEFAULT: Driver selects Quarter-Pel motion vector precision by default</summary>
         Default = 0x0,
-        /// <summary>NV_ENC_MV_PRECISION_FULL_PEL: FullPel motion vector precision</summary>
+        /// <summary>NV_ENC_MV_PRECISION_FULL_PEL: Full-Pel motion vector precision</summary>
         FullPel = 0x01,
-        /// <summary>NV_ENC_MV_PRECISION_HALF_PEL: HalfPel motion vector precision</summary>
+        /// <summary>NV_ENC_MV_PRECISION_HALF_PEL: Half-Pel motion vector precision</summary>
         HalfPel = 0x02,
-        /// <summary>NV_ENC_MV_PRECISION_QUARTER_PEL: QuarterPel motion vector precision</summary>
+        /// <summary>NV_ENC_MV_PRECISION_QUARTER_PEL: Quarter-Pel motion vector precision</summary>
         QuarterPel = 0x03,
     }
 
@@ -202,6 +248,12 @@ namespace Lennox.NvEncSharp
         H26451 = 51,
         /// <summary>NV_ENC_LEVEL_H264_52</summary>
         H26452 = 52,
+        /// <summary>NV_ENC_LEVEL_H264_60</summary>
+        H26460 = 60,
+        /// <summary>NV_ENC_LEVEL_H264_61</summary>
+        H26461 = 61,
+        /// <summary>NV_ENC_LEVEL_H264_62</summary>
+        H26462 = 62,
         /// <summary>NV_ENC_LEVEL_HEVC_1</summary>
         Hevc1 = 30,
         /// <summary>NV_ENC_LEVEL_HEVC_2</summary>
@@ -232,6 +284,54 @@ namespace Lennox.NvEncSharp
         TierHevcMain = 0,
         /// <summary>NV_ENC_TIER_HEVC_HIGH</summary>
         TierHevcHigh = 1,
+        /// <summary>NV_ENC_LEVEL_AV1_2</summary>
+        Av12 = 0,
+        /// <summary>NV_ENC_LEVEL_AV1_21</summary>
+        Av121 = 1,
+        /// <summary>NV_ENC_LEVEL_AV1_22</summary>
+        Av122 = 2,
+        /// <summary>NV_ENC_LEVEL_AV1_23</summary>
+        Av123 = 3,
+        /// <summary>NV_ENC_LEVEL_AV1_3</summary>
+        Av13 = 4,
+        /// <summary>NV_ENC_LEVEL_AV1_31</summary>
+        Av131 = 5,
+        /// <summary>NV_ENC_LEVEL_AV1_32</summary>
+        Av132 = 6,
+        /// <summary>NV_ENC_LEVEL_AV1_33</summary>
+        Av133 = 7,
+        /// <summary>NV_ENC_LEVEL_AV1_4</summary>
+        Av14 = 8,
+        /// <summary>NV_ENC_LEVEL_AV1_41</summary>
+        Av141 = 9,
+        /// <summary>NV_ENC_LEVEL_AV1_42</summary>
+        Av142 = 10,
+        /// <summary>NV_ENC_LEVEL_AV1_43</summary>
+        Av143 = 11,
+        /// <summary>NV_ENC_LEVEL_AV1_5</summary>
+        Av15 = 12,
+        /// <summary>NV_ENC_LEVEL_AV1_51</summary>
+        Av151 = 13,
+        /// <summary>NV_ENC_LEVEL_AV1_52</summary>
+        Av152 = 14,
+        /// <summary>NV_ENC_LEVEL_AV1_53</summary>
+        Av153 = 15,
+        /// <summary>NV_ENC_LEVEL_AV1_6</summary>
+        Av16 = 16,
+        /// <summary>NV_ENC_LEVEL_AV1_61</summary>
+        Av161 = 17,
+        /// <summary>NV_ENC_LEVEL_AV1_62</summary>
+        Av162 = 18,
+        /// <summary>NV_ENC_LEVEL_AV1_63</summary>
+        Av163 = 19,
+        /// <summary>NV_ENC_LEVEL_AV1_7</summary>
+        Av17 = 20,
+        /// <summary>NV_ENC_LEVEL_AV1_71</summary>
+        Av171 = 21,
+        /// <summary>NV_ENC_LEVEL_AV1_72</summary>
+        Av172 = 22,
+        /// <summary>NV_ENC_LEVEL_AV1_73</summary>
+        Av173 = 23,
     }
 
     /// <summary>NVENCSTATUS</summary>
@@ -324,6 +424,13 @@ namespace Lennox.NvEncSharp
         /// <summary>NV_ENC_ERR_RESOURCE_NOT_MAPPED:  This indicates that the client is attempting to unmap a resource
         ///  * that has not been successfully mapped.</summary>
         ResourceNotMapped,
+        /// <summary>NV_ENC_ERR_NEED_MORE_OUTPUT:  This indicates encode driver requires more output buffers to write an output
+        ///  * bitstream. If this error is returned from ::NvEncRestoreEncoderState() API, this
+        ///  * is not a fatal error. If the client is encoding with B frames then,
+        ///  * ::NvEncRestoreEncoderState() API might be requiring the extra output buffer for accomodating overlay frame output in a separate buffer, for AV1 codec.
+        ///  * In this case, client must call NvEncRestoreEncoderState() API again with NV_ENC_RESTORE_ENCODER_STATE_PARAMS::outputBitstream as input along with 
+        ///  * the parameters in the previous call. When operating in asynchronous mode of encoding, client must also specify NV_ENC_RESTORE_ENCODER_STATE_PARAMS::completionEvent.</summary>
+        NeedMoreOutput,
     }
 
     /// <summary>NV_ENC_PIC_FLAGS</summary>
@@ -331,7 +438,7 @@ namespace Lennox.NvEncSharp
     {
         /// <summary>NV_ENC_PIC_FLAG_FORCEINTRA: Encode the current picture as an Intra picture</summary>
         FlagForceintra = 0x1,
-        /// <summary>NV_ENC_PIC_FLAG_FORCEIDR: Encode the current picture as an IDR picture.
+        /// <summary>NV_ENC_PIC_FLAG_FORCEIDR: Encode the current picture as an IDR picture. 
         ///  This flag is only valid when Picture type decision is taken by the Encoder
         ///  [_NV_ENC_INITIALIZE_PARAMS::enablePTD == 1].</summary>
         FlagForceidr = 0x2,
@@ -339,6 +446,10 @@ namespace Lennox.NvEncSharp
         FlagOutputSpspps = 0x4,
         /// <summary>NV_ENC_PIC_FLAG_EOS: Indicates end of the input stream</summary>
         FlagEos = 0x8,
+        /// <summary>NV_ENC_PIC_FLAG_DISABLE_ENC_STATE_ADVANCE: Do not advance encoder state during encode</summary>
+        FlagDisableEncStateAdvance = 0x10,
+        /// <summary>NV_ENC_PIC_FLAG_OUTPUT_RECON_FRAME: Write reconstructed frame</summary>
+        FlagOutputReconFrame = 0x20,
     }
 
     /// <summary>NV_ENC_MEMORY_HEAP</summary>
@@ -359,7 +470,7 @@ namespace Lennox.NvEncSharp
     {
         /// <summary>NV_ENC_BFRAME_REF_MODE_DISABLED: B frame is not used for reference</summary>
         Disabled = 0x0,
-        /// <summary>NV_ENC_BFRAME_REF_MODE_EACH: Each B-frame will be used for reference. currently not supported for H.264</summary>
+        /// <summary>NV_ENC_BFRAME_REF_MODE_EACH: Each B-frame will be used for reference</summary>
         Each = 0x1,
         /// <summary>NV_ENC_BFRAME_REF_MODE_MIDDLE: Only(Number of B-frame)/2 th B-frame will be used for reference</summary>
         Middle = 0x2,
@@ -396,7 +507,7 @@ namespace Lennox.NvEncSharp
         Autoselect = 0x0,
         /// <summary>NV_ENC_H264_FMO_ENABLE: Enable FMO</summary>
         Enable = 0x1,
-        /// <summary>NV_ENC_H264_FMO_DISABLE: Disble FMO</summary>
+        /// <summary>NV_ENC_H264_FMO_DISABLE: Disable FMO</summary>
         Disable = 0x2,
     }
 
@@ -455,6 +566,8 @@ namespace Lennox.NvEncSharp
         NvEncOutputMotionVector = 0x1,
         /// <summary>NV_ENC_OUTPUT_BITSTREAM: Registered surface will be used for output bitstream in encoding</summary>
         NvEncOutputBitstream = 0x2,
+        /// <summary>NV_ENC_OUTPUT_RECON: Registered surface will be used for output reconstructed frame in encoding</summary>
+        NvEncOutputRecon = 0x4,
     }
 
     /// <summary>NV_ENC_DEVICE_TYPE</summary>
@@ -490,6 +603,15 @@ namespace Lennox.NvEncSharp
         Frames7 = 0x7,
     }
 
+    /// <summary>NV_ENC_TEMPORAL_FILTER_LEVEL</summary>
+    public enum NvEncTemporalFilterLevel
+    {
+        /// <summary>NV_ENC_TEMPORAL_FILTER_LEVEL_0</summary>
+        Level0 = 0,
+        /// <summary>NV_ENC_TEMPORAL_FILTER_LEVEL_4</summary>
+        Level4 = 4,
+    }
+
     /// <summary>NV_ENC_CAPS</summary>
     public enum NvEncCaps
     {
@@ -512,8 +634,8 @@ namespace Lennox.NvEncSharp
         ///  * \n 1 : FMO supported.</summary>
         SupportFmo,
         /// <summary>NV_ENC_CAPS_SUPPORT_QPELMV:  Indicates HW capability for Quarter pel motion estimation.
-        ///  * \n 0 : QuarterPel Motion Estimation not supported.
-        ///  * \n 1 : QuarterPel Motion Estimation supported.</summary>
+        ///  * \n 0 : Quarter-Pel Motion Estimation not supported.
+        ///  * \n 1 : Quarter-Pel Motion Estimation supported.</summary>
         SupportQpelmv,
         /// <summary>NV_ENC_CAPS_SUPPORT_BDIRECT_MODE:  H.264 specific. Indicates HW support for BDirect modes.
         ///  * \n 0 : BDirect mode encoding not supported.
@@ -578,18 +700,17 @@ namespace Lennox.NvEncSharp
         ///  * \n 0 : Dynamic rate control mode change not supported.
         ///  * \n 1 : Dynamic rate control mode change supported.</summary>
         SupportDynRcmodeChange,
-        /// <summary>NV_ENC_CAPS_SUPPORT_SUBFRAME_READBACK:  Indicates Subframe readback support for slice-based encoding.
+        /// <summary>NV_ENC_CAPS_SUPPORT_SUBFRAME_READBACK:  Indicates Subframe readback support for slice-based encoding. If this feature is supported, it can be enabled by setting enableSubFrameWrite = 1.
         ///  * \n 0 : Subframe readback not supported.
         ///  * \n 1 : Subframe readback supported.</summary>
         SupportSubframeReadback,
         /// <summary>NV_ENC_CAPS_SUPPORT_CONSTRAINED_ENCODING:  Indicates Constrained Encoding mode support.
         ///  * Support added from NvEncodeAPI version 2.0.
         ///  * \n 0 : Constrained encoding mode not supported.
-        ///  * \n 1 : Constarined encoding mode supported.
-        ///  * If this mode is supported client can enable this during initialisation.
+        ///  * \n 1 : Constrained encoding mode supported.
+        ///  * If this mode is supported client can enable this during initialization.
         ///  * Client can then force a picture to be coded as constrained picture where
-        ///  * each slice in a constrained picture will have constrained_intra_pred_flag set to 1
-        ///  * and disable_deblocking_filter_idc will be set to 2 and prediction vectors for inter
+        ///  * in-loop filtering is disabled across slice boundaries and prediction vectors for inter
         ///  * macroblocks in each slice will be restricted to the slice region.</summary>
         SupportConstrainedEncoding,
         /// <summary>NV_ENC_CAPS_SUPPORT_INTRA_REFRESH:  Indicates Intra Refresh Mode Support.
@@ -597,7 +718,7 @@ namespace Lennox.NvEncSharp
         ///  * \n 0 : Intra Refresh Mode not supported.
         ///  * \n 1 : Intra Refresh Mode supported.</summary>
         SupportIntraRefresh,
-        /// <summary>NV_ENC_CAPS_SUPPORT_CUSTOM_VBV_BUF_SIZE:  Indicates Custom VBV Bufer Size support. It can be used for capping frame size.
+        /// <summary>NV_ENC_CAPS_SUPPORT_CUSTOM_VBV_BUF_SIZE:  Indicates Custom VBV Buffer Size support. It can be used for capping frame size.
         ///  * Support added from NvEncodeAPI version 2.0.
         ///  * \n 0 : Custom VBV buffer size specification from client, not supported.
         ///  * \n 1 : Custom VBV buffer size specification from client, supported.</summary>
@@ -612,7 +733,7 @@ namespace Lennox.NvEncSharp
         ///  * \n 0 : Reference Picture Invalidation not supported.
         ///  * \n 1 : Reference Picture Invalidation supported.</summary>
         SupportRefPicInvalidation,
-        /// <summary>NV_ENC_CAPS_PREPROC_SUPPORT:  Indicates support for PreProcessing.
+        /// <summary>NV_ENC_CAPS_PREPROC_SUPPORT:  Indicates support for Pre-Processing.
         ///  * The API return value is a bitmask of the values defined in ::NV_ENC_PREPROC_FLAGS</summary>
         PreprocSupport,
         /// <summary>NV_ENC_CAPS_ASYNC_ENCODE_SUPPORT:  Indicates support Async mode.
@@ -635,7 +756,7 @@ namespace Lennox.NvEncSharp
         ///  * \n 0 : SAO not supported.
         ///  * \n 1 : SAO encoding supported.</summary>
         SupportSao,
-        /// <summary>NV_ENC_CAPS_SUPPORT_MEONLY_MODE:  Indicates HW support for MEOnly Mode.
+        /// <summary>NV_ENC_CAPS_SUPPORT_MEONLY_MODE:  Indicates HW support for Motion Estimation Only Mode.
         ///  * \n 0 : MEOnly Mode not supported.
         ///  * \n 1 : MEOnly Mode supported for I and P frames.
         ///  * \n 2 : MEOnly Mode supported for I, P and B frames.</summary>
@@ -654,9 +775,9 @@ namespace Lennox.NvEncSharp
         Support10bitEncode,
         /// <summary>NV_ENC_CAPS_NUM_MAX_LTR_FRAMES:  Maximum number of Long Term Reference frames supported</summary>
         NumMaxLtrFrames,
-        /// <summary>NV_ENC_CAPS_SUPPORT_WEIGHTED_PREDICTION:  Indicates HW support for Weighted Predicition.
-        ///  * \n 0 : Weighted Predicition not supported.
-        ///  * \n 1 : Weighted Predicition supported.</summary>
+        /// <summary>NV_ENC_CAPS_SUPPORT_WEIGHTED_PREDICTION:  Indicates HW support for Weighted Prediction.
+        ///  * \n 0 : Weighted Prediction not supported.
+        ///  * \n 1 : Weighted Prediction supported.</summary>
         SupportWeightedPrediction,
         /// <summary>NV_ENC_CAPS_DYNAMIC_QUERY_ENCODER_CAPACITY:  On managed (vGPU) platforms (Windows only), this API, in conjunction with other GRID Management APIs, can be used
         ///  * to estimate the residual capacity of the hardware encoder on the GPU as a percentage of the total available encoder capacity.
@@ -664,9 +785,9 @@ namespace Lennox.NvEncSharp
         ///  * If the available encoder capacity is returned as zero, applications may choose to switch to software encoding
         ///  * and continue to call this API (e.g. polling once per second) until capacity becomes available.
         ///  *
-        ///  * On baremetal (non-virtualized GPU) and linux platforms, this API always returns 100.</summary>
+        ///  * On bare metal (non-virtualized GPU) and linux platforms, this API always returns 100.</summary>
         DynamicQueryEncoderCapacity,
-        /// <summary>NV_ENC_CAPS_SUPPORT_BFRAME_REF_MODE:  Indicates B as refererence support.
+        /// <summary>NV_ENC_CAPS_SUPPORT_BFRAME_REF_MODE:  Indicates B as reference support.
         ///  * \n 0 : B as reference is not supported.
         ///  * \n 1 : each B-Frame as reference is supported.
         ///  * \n 2 : only Middle B-frame as reference is supported.</summary>
@@ -681,6 +802,28 @@ namespace Lennox.NvEncSharp
         HeightMin,
         /// <summary>NV_ENC_CAPS_SUPPORT_MULTIPLE_REF_FRAMES:  Indicates HW support for multiple reference frames.</summary>
         SupportMultipleRefFrames,
+        /// <summary>NV_ENC_CAPS_SUPPORT_ALPHA_LAYER_ENCODING:  Indicates HW support for HEVC with alpha encoding.
+        ///  * \n 0 : HEVC with alpha encoding not supported.
+        ///  * \n 1 : HEVC with alpha encoding is supported.</summary>
+        SupportAlphaLayerEncoding,
+        /// <summary>NV_ENC_CAPS_NUM_ENCODER_ENGINES:  Indicates number of Encoding engines present on GPU.</summary>
+        NumEncoderEngines,
+        /// <summary>NV_ENC_CAPS_SINGLE_SLICE_INTRA_REFRESH:  Indicates single slice intra refresh support.</summary>
+        SingleSliceIntraRefresh,
+        /// <summary>NV_ENC_CAPS_DISABLE_ENC_STATE_ADVANCE:  Indicates encoding without advancing the state support.</summary>
+        DisableEncStateAdvance,
+        /// <summary>NV_ENC_CAPS_OUTPUT_RECON_SURFACE:  Indicates reconstructed output support.</summary>
+        OutputReconSurface,
+        /// <summary>NV_ENC_CAPS_OUTPUT_BLOCK_STATS:  Indicates encoded frame output stats support for every block. Block represents a CTB for HEVC, macroblock for H.264 and super block for AV1.</summary>
+        OutputBlockStats,
+        /// <summary>NV_ENC_CAPS_OUTPUT_ROW_STATS:  Indicates encoded frame output stats support for every row. Row represents a CTB row for HEVC, macroblock row for H.264 and super block row for AV1.</summary>
+        OutputRowStats,
+        /// <summary>NV_ENC_CAPS_SUPPORT_TEMPORAL_FILTER:  Indicates temporal filtering support.</summary>
+        SupportTemporalFilter,
+        /// <summary>NV_ENC_CAPS_SUPPORT_LOOKAHEAD_LEVEL:  Maximum Lookahead level supported (See ::NV_ENC_LOOKAHEAD_LEVEL for details).</summary>
+        SupportLookaheadLevel,
+        /// <summary>NV_ENC_CAPS_SUPPORT_UNIDIRECTIONAL_B:  Indicates UnidirectionalB support.</summary>
+        SupportUnidirectionalB,
     }
 
     /// <summary>NV_ENC_HEVC_CUSIZE</summary>
@@ -698,4 +841,216 @@ namespace Lennox.NvEncSharp
         Cusize64x64 = 4,
     }
 
+    /// <summary>NV_ENC_AV1_PART_SIZE</summary>
+    public enum NvEncAv1PartSize
+    {
+        /// <summary>NV_ENC_AV1_PART_SIZE_AUTOSELECT</summary>
+        Autoselect = 0,
+        /// <summary>NV_ENC_AV1_PART_SIZE_4x4</summary>
+        Size4x4 = 1,
+        /// <summary>NV_ENC_AV1_PART_SIZE_8x8</summary>
+        Size8x8 = 2,
+        /// <summary>NV_ENC_AV1_PART_SIZE_16x16</summary>
+        Size16x16 = 3,
+        /// <summary>NV_ENC_AV1_PART_SIZE_32x32</summary>
+        Size32x32 = 4,
+        /// <summary>NV_ENC_AV1_PART_SIZE_64x64</summary>
+        Size64x64 = 5,
+    }
+
+    /// <summary>NV_ENC_VUI_VIDEO_FORMAT</summary>
+    public enum NvEncVuiVideoFormat
+    {
+        /// <summary>NV_ENC_VUI_VIDEO_FORMAT_COMPONENT</summary>
+        Component = 0,
+        /// <summary>NV_ENC_VUI_VIDEO_FORMAT_PAL</summary>
+        Pal = 1,
+        /// <summary>NV_ENC_VUI_VIDEO_FORMAT_NTSC</summary>
+        Ntsc = 2,
+        /// <summary>NV_ENC_VUI_VIDEO_FORMAT_SECAM</summary>
+        Secam = 3,
+        /// <summary>NV_ENC_VUI_VIDEO_FORMAT_MAC</summary>
+        Mac = 4,
+        /// <summary>NV_ENC_VUI_VIDEO_FORMAT_UNSPECIFIED</summary>
+        Unspecified = 5,
+    }
+
+    /// <summary>NV_ENC_VUI_COLOR_PRIMARIES</summary>
+    public enum NvEncVuiColorPrimaries
+    {
+        /// <summary>NV_ENC_VUI_COLOR_PRIMARIES_UNDEFINED</summary>
+        Undefined = 0,
+        /// <summary>NV_ENC_VUI_COLOR_PRIMARIES_BT709</summary>
+        Bt709 = 1,
+        /// <summary>NV_ENC_VUI_COLOR_PRIMARIES_UNSPECIFIED</summary>
+        Unspecified = 2,
+        /// <summary>NV_ENC_VUI_COLOR_PRIMARIES_RESERVED</summary>
+        Reserved = 3,
+        /// <summary>NV_ENC_VUI_COLOR_PRIMARIES_BT470M</summary>
+        Bt470m = 4,
+        /// <summary>NV_ENC_VUI_COLOR_PRIMARIES_BT470BG</summary>
+        Bt470bg = 5,
+        /// <summary>NV_ENC_VUI_COLOR_PRIMARIES_SMPTE170M</summary>
+        Smpte170m = 6,
+        /// <summary>NV_ENC_VUI_COLOR_PRIMARIES_SMPTE240M</summary>
+        Smpte240m = 7,
+        /// <summary>NV_ENC_VUI_COLOR_PRIMARIES_FILM</summary>
+        Film = 8,
+        /// <summary>NV_ENC_VUI_COLOR_PRIMARIES_BT2020</summary>
+        Bt2020 = 9,
+        /// <summary>NV_ENC_VUI_COLOR_PRIMARIES_SMPTE428</summary>
+        Smpte428 = 10,
+        /// <summary>NV_ENC_VUI_COLOR_PRIMARIES_SMPTE431</summary>
+        Smpte431 = 11,
+        /// <summary>NV_ENC_VUI_COLOR_PRIMARIES_SMPTE432</summary>
+        Smpte432 = 12,
+        /// <summary>NV_ENC_VUI_COLOR_PRIMARIES_JEDEC_P22</summary>
+        JedecP22 = 22,
+    }
+
+    /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC</summary>
+    public enum NvEncVuiTransferCharacteristic
+    {
+        /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC_UNDEFINED</summary>
+        Undefined = 0,
+        /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT709</summary>
+        Bt709 = 1,
+        /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC_UNSPECIFIED</summary>
+        Unspecified = 2,
+        /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC_RESERVED</summary>
+        Reserved = 3,
+        /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT470M</summary>
+        Bt470m = 4,
+        /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT470BG</summary>
+        Bt470bg = 5,
+        /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC_SMPTE170M</summary>
+        Smpte170m = 6,
+        /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC_SMPTE240M</summary>
+        Smpte240m = 7,
+        /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC_LINEAR</summary>
+        Linear = 8,
+        /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC_LOG</summary>
+        Log = 9,
+        /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC_LOG_SQRT</summary>
+        LogSqrt = 10,
+        /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC_IEC61966_2_4</summary>
+        Iec6196624 = 11,
+        /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT1361_ECG</summary>
+        Bt1361Ecg = 12,
+        /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC_SRGB</summary>
+        Srgb = 13,
+        /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT2020_10</summary>
+        Bt202010 = 14,
+        /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT2020_12</summary>
+        Bt202012 = 15,
+        /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC_SMPTE2084</summary>
+        Smpte2084 = 16,
+        /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC_SMPTE428</summary>
+        Smpte428 = 17,
+        /// <summary>NV_ENC_VUI_TRANSFER_CHARACTERISTIC_ARIB_STD_B67</summary>
+        AribStdB67 = 18,
+    }
+
+    /// <summary>NV_ENC_VUI_MATRIX_COEFFS</summary>
+    public enum NvEncVuiMatrixCoeffs
+    {
+        /// <summary>NV_ENC_VUI_MATRIX_COEFFS_RGB</summary>
+        Rgb = 0,
+        /// <summary>NV_ENC_VUI_MATRIX_COEFFS_BT709</summary>
+        Bt709 = 1,
+        /// <summary>NV_ENC_VUI_MATRIX_COEFFS_UNSPECIFIED</summary>
+        Unspecified = 2,
+        /// <summary>NV_ENC_VUI_MATRIX_COEFFS_RESERVED</summary>
+        Reserved = 3,
+        /// <summary>NV_ENC_VUI_MATRIX_COEFFS_FCC</summary>
+        Fcc = 4,
+        /// <summary>NV_ENC_VUI_MATRIX_COEFFS_BT470BG</summary>
+        Bt470bg = 5,
+        /// <summary>NV_ENC_VUI_MATRIX_COEFFS_SMPTE170M</summary>
+        Smpte170m = 6,
+        /// <summary>NV_ENC_VUI_MATRIX_COEFFS_SMPTE240M</summary>
+        Smpte240m = 7,
+        /// <summary>NV_ENC_VUI_MATRIX_COEFFS_YCGCO</summary>
+        Ycgco = 8,
+        /// <summary>NV_ENC_VUI_MATRIX_COEFFS_BT2020_NCL</summary>
+        Bt2020Ncl = 9,
+        /// <summary>NV_ENC_VUI_MATRIX_COEFFS_BT2020_CL</summary>
+        Bt2020Cl = 10,
+        /// <summary>NV_ENC_VUI_MATRIX_COEFFS_SMPTE2085</summary>
+        Smpte2085 = 11,
+    }
+
+    /// <summary>NV_ENC_LOOKAHEAD_LEVEL</summary>
+    public enum NvEncLookaheadLevel
+    {
+        /// <summary>NV_ENC_LOOKAHEAD_LEVEL_0</summary>
+        Level0 = 0,
+        /// <summary>NV_ENC_LOOKAHEAD_LEVEL_1</summary>
+        Level1 = 1,
+        /// <summary>NV_ENC_LOOKAHEAD_LEVEL_2</summary>
+        Level2 = 2,
+        /// <summary>NV_ENC_LOOKAHEAD_LEVEL_3</summary>
+        Level3 = 3,
+        /// <summary>NV_ENC_LOOKAHEAD_LEVEL_AUTOSELECT</summary>
+        Autoselect = 15,
+    }
+
+    /// <summary>NV_ENC_BIT_DEPTH</summary>
+    public enum NvEncBitDepth
+    {
+        /// <summary>NV_ENC_BIT_DEPTH_INVALID: Invalid Bit Depth</summary>
+        Invalid = 0,
+        /// <summary>NV_ENC_BIT_DEPTH_8: Bit Depth 8</summary>
+        Depth8 = 8,
+        /// <summary>NV_ENC_BIT_DEPTH_10: Bit Depth 10</summary>
+        Depth10 = 10,
+    }
+
+    /// <summary>NV_ENC_SPLIT_ENCODE_MODE</summary>
+    public enum NvEncSplitEncodeMode
+    {
+        /// <summary>NV_ENC_SPLIT_AUTO_MODE: Default value, split frame forced mode disabled, split frame auto mode enabled</summary>
+        NvEncSplitAutoMode = 0,
+        /// <summary>NV_ENC_SPLIT_AUTO_FORCED_MODE: Split frame forced mode enabled with number of strips automatically selected by driver to best fit configuration</summary>
+        NvEncSplitAutoForcedMode = 1,
+        /// <summary>NV_ENC_SPLIT_TWO_FORCED_MODE: Forced 2-strip split frame encoding (if NVENC number > 1, 1-strip encode otherwise)</summary>
+        NvEncSplitTwoForcedMode = 2,
+        /// <summary>NV_ENC_SPLIT_THREE_FORCED_MODE: Forced 3-strip split frame encoding (if NVENC number > 2, NVENC number of strips otherwise)</summary>
+        NvEncSplitThreeForcedMode = 3,
+        /// <summary>NV_ENC_SPLIT_DISABLE_MODE: Both split frame auto mode and forced mode are disabled</summary>
+        NvEncSplitDisableMode = 15,
+    }
+
+    public enum NvEncTuningInfo
+    {
+        /// <summary>
+        /// Undefined tuningInfo. Invalid value for encoding.
+        /// </summary>
+        Undefined = 0,
+
+        /// <summary>
+        /// Tune presets for latency tolerant encoding.
+        /// </summary>
+        HighQuality = 1,
+
+        /// <summary>
+        /// Tune presets for low latency streaming.
+        /// </summary>
+        LowLatency = 2,
+
+        /// <summary>
+        /// Tune presets for ultra low latency streaming.
+        /// </summary>
+        UltraLowLatency = 3,
+
+        /// <summary>
+        /// Tune presets for lossless encoding.
+        /// </summary>
+        Lossless = 4,
+
+        /// <summary>
+        /// Tune presets for latency tolerant encoding for higher quality. Only supported for HEVC and AV1 on Turing+ architectures 
+        /// </summary>
+        UltraHighQuality = 5,
+    }
 }

--- a/src/NvEncSharp/Guids.cs
+++ b/src/NvEncSharp/Guids.cs
@@ -7,6 +7,7 @@ namespace Lennox.NvEncSharp
     {
         public static Guid H264 = Guid.Parse("6BC82762-4E63-4ca4-AA85-1E50F321F6BF");
         public static Guid Hevc = Guid.Parse("790CDC88-4522-4d7b-9425-BDA9975F7603");
+        public static Guid Av1 = Guid.Parse("0A352289-0AA7-4759-862D-5D15CD16D254");
     }
 
     public static class NvEncProfileGuids
@@ -17,25 +18,23 @@ namespace Lennox.NvEncSharp
         public static readonly Guid H264High = Guid.Parse("E7CBC309-4F7A-4b89-AF2A-D537C92BE310");
         public static readonly Guid H264High444 = Guid.Parse("7AC663CB-A598-4960-B844-339B261A7D52");
         public static readonly Guid H264Stereo = Guid.Parse("40847BF5-33F7-4601-9084-E8FE3C1DB8B7");
-        public static readonly Guid H264SvcTemporalScalabilty = Guid.Parse("CE788D20-AAA9-4318-92BB-AC7E858C8D36");
         public static readonly Guid H264ProgressiveHigh = Guid.Parse("B405AFAC-F32B-417B-89C4-9ABEED3E5978");
         public static readonly Guid H264ConstrainedHigh = Guid.Parse("AEC1BD87-E85B-48f2-84C3-98BCA6285072");
         public static readonly Guid HevcMain = Guid.Parse("B514C39A-B55B-40fa-878F-F1253B4DFDEC");
         public static readonly Guid HevcMain10 = Guid.Parse("fa4d2b6c-3a5b-411a-8018-0a3f5e3c9be5");
         /// <summary>For HEVC Main 444 8 bit and HEVC Main 444 10 bit profiles only</summary>
         public static readonly Guid HevcFrext = Guid.Parse("51ec32b5-1b4c-453c-9cbd-b616bd621341");
+        public static readonly Guid Av1Main = Guid.Parse("5f2a39f5-f14e-4f95-9a9e-b76d568fcf97");
     }
 
     public static class NvEncPresetGuids
     {
-        public static readonly Guid Default = Guid.Parse("B2DFB705-4EBD-4C49-9B5F-24A777D3E587");
-        public static readonly Guid Hp = Guid.Parse("60E4C59F-E846-4484-A56D-CD45BE9FDDF6");
-        public static readonly Guid Hq = Guid.Parse("34DBA71D-A77B-4B8F-9C3E-B6D5DA24C012");
-        public static readonly Guid Bd = Guid.Parse("82E3E450-BDBB-4e40-989C-82A90DF9EF32");
-        public static readonly Guid LowLatencyDefault = Guid.Parse("49DF21C5-6DFA-4feb-9787-6ACC9EFFB726");
-        public static readonly Guid LowLatencyHq = Guid.Parse("C5F733B9-EA97-4cf9-BEC2-BF78A74FD105");
-        public static readonly Guid LowLatencyHp = Guid.Parse("67082A44-4BAD-48FA-98EA-93056D150A58");
-        public static readonly Guid LosslessDefault = Guid.Parse("D5BFB716-C604-44e7-9BB8-DEA5510FC3AC");
-        public static readonly Guid LosslessHp = Guid.Parse("149998E7-2364-411d-82EF-179888093409");
+        public static readonly Guid P1 = Guid.Parse("FC0A8D3E-45F8-4CF8-80C7-298871590EBF");
+        public static readonly Guid P2 = Guid.Parse("F581CFB8-88D6-4381-93F0-DF13F9C27DAB");
+        public static readonly Guid P3 = Guid.Parse("36850110-3A07-441F-94D5-3670631F91F6");
+        public static readonly Guid P4 = Guid.Parse("90A7B826-DF06-4862-B9D2-CD6D73A08681");
+        public static readonly Guid P5 = Guid.Parse("21C6E6B4-297A-4CBA-998F-B6CBDE72ADE3");
+        public static readonly Guid P6 = Guid.Parse("8E75C279-6299-4AB6-8302-0B215A335CF5");
+        public static readonly Guid P7 = Guid.Parse("84848C12-6F71-4C13-931B-53E283F57974");
     }
 }

--- a/src/NvEncSharp/LibNvEnc.cs
+++ b/src/NvEncSharp/LibNvEnc.cs
@@ -19,8 +19,8 @@ namespace Lennox.NvEncSharp
 
         // ReSharper disable InconsistentNaming
         // ReSharper disable UnusedMember.Global
-        public const uint NVENCAPI_MAJOR_VERSION = 9;
-        public const uint NVENCAPI_MINOR_VERSION = 1;
+        public const uint NVENCAPI_MAJOR_VERSION = 12;
+        public const uint NVENCAPI_MINOR_VERSION = 2;
 
         public const uint NVENCAPI_VERSION = NVENCAPI_MAJOR_VERSION | (NVENCAPI_MINOR_VERSION << 24);
 
@@ -28,22 +28,22 @@ namespace Lennox.NvEncSharp
         public static readonly uint NV_ENC_ENCODE_OUT_PARAMS_VER = StructVersion(1);
         public static readonly uint NV_ENC_CREATE_INPUT_BUFFER_VER = StructVersion(1);
         public static readonly uint NV_ENC_CREATE_BITSTREAM_BUFFER_VER = StructVersion(1);
-        public static readonly uint NV_ENC_CREATE_MV_BUFFER_VER = StructVersion(1);
+        public static readonly uint NV_ENC_CREATE_MV_BUFFER_VER = StructVersion(2);
         public static readonly uint NV_ENC_RC_PARAMS_VER = StructVersion(1);
-        public static readonly uint NV_ENC_CONFIG_VER = StructVersion(7, (uint)1 << 31);
-        public static readonly uint NV_ENC_INITIALIZE_PARAMS_VER = StructVersion(5, (uint)1 << 31);
-        public static readonly uint NV_ENC_RECONFIGURE_PARAMS_VER = StructVersion(1, (uint)1 << 31);
-        public static readonly uint NV_ENC_PRESET_CONFIG_VER = StructVersion(4, (uint)1 << 31);
+        public static readonly uint NV_ENC_CONFIG_VER = StructVersion(9, 1);
+        public static readonly uint NV_ENC_INITIALIZE_PARAMS_VER = StructVersion(7, 1);
+        public static readonly uint NV_ENC_RECONFIGURE_PARAMS_VER = StructVersion(2, 1);
+        public static readonly uint NV_ENC_PRESET_CONFIG_VER = StructVersion(5, 1);
         public static readonly uint NV_ENC_PIC_PARAMS_MVC_VER = StructVersion(1);
-        public static readonly uint NV_ENC_PIC_PARAMS_VER = StructVersion(4, (uint)1 << 31);
-        public static readonly uint NV_ENC_MEONLY_PARAMS_VER = StructVersion(3);
-        public static readonly uint NV_ENC_LOCK_BITSTREAM_VER = StructVersion(1);
+        public static readonly uint NV_ENC_PIC_PARAMS_VER = StructVersion(7, 1);
+        public static readonly uint NV_ENC_MEONLY_PARAMS_VER = StructVersion(4);
+        public static readonly uint NV_ENC_LOCK_BITSTREAM_VER = StructVersion(2, 1);
         public static readonly uint NV_ENC_LOCK_INPUT_BUFFER_VER = StructVersion(1);
         public static readonly uint NV_ENC_MAP_INPUT_RESOURCE_VER = StructVersion(4);
-        public static readonly uint NV_ENC_REGISTER_RESOURCE_VER = StructVersion(3);
-        public static readonly uint NV_ENC_STAT_VER = StructVersion(1);
+        public static readonly uint NV_ENC_REGISTER_RESOURCE_VER = StructVersion(5);
+        public static readonly uint NV_ENC_STAT_VER = StructVersion(2);
         public static readonly uint NV_ENC_SEQUENCE_PARAM_PAYLOAD_VER = StructVersion(1);
-        public static readonly uint NV_ENC_EVENT_PARAMS_VER = StructVersion(1);
+        public static readonly uint NV_ENC_EVENT_PARAMS_VER = StructVersion(2);
         public static readonly uint NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS_VER = StructVersion(1);
         public static readonly uint NV_ENCODE_API_FUNCTION_LIST_VER = StructVersion(2);
         // ReSharper restore UnusedMember.Global
@@ -111,7 +111,7 @@ namespace Lennox.NvEncSharp
         private static uint StructVersion(uint ver, uint and = 0)
         {
             // #define NVENCAPI_STRUCT_VERSION(ver) ((uint32_t)NVENCAPI_VERSION | ((ver)<<16) | (0x7 << 28))
-            return NVENCAPI_VERSION | (ver << 16) | (0x7 << 28) | and;
+            return NVENCAPI_VERSION | (ver << 16) | (0x7 << 28) | (and << 31);
         }
 
         /// <summary>

--- a/src/NvEncSharp/NvEncApiFunctionList.cs
+++ b/src/NvEncSharp/NvEncApiFunctionList.cs
@@ -92,6 +92,8 @@ namespace Lennox.NvEncSharp
         public GetLastErrorFn GetLastError;
         public delegate NvEncStatus SetIOCudaStreamsFn(NvEncoder encoder, NvEncCustreamPtr inputStream, NvEncCustreamPtr outputStream);
         public SetIOCudaStreamsFn SetIOCudaStreams;
-        public fixed long Reserved2[279];
+        public delegate NvEncStatus GetEncodePresetConfigExFn(NvEncoder encoder, Guid encodeGuid, Guid presetGuid, uint tuningInfo, ref NvEncPresetConfig presetConfig);
+        public GetEncodePresetConfigExFn GetEncodePresetConfigEx;
+        public fixed long Reserved2[278];
     }
 }

--- a/src/NvEncSharp/NvEncoder.cs
+++ b/src/NvEncSharp/NvEncoder.cs
@@ -379,17 +379,35 @@ namespace Lennox.NvEncSharp
         /// ::NV_ENC_ERR_GENERIC</returns>
         ///
         /// <summary>NV_ENC_CONFIG</summary>
-        public void GetEncodePresetConfig(
-            Guid encodeGuid, Guid presetGuid,
-            ref NvEncPresetConfig presetConfig)
+        public void GetEncodePresetConfig(Guid encodeGuid, Guid presetGuid, ref NvEncPresetConfig presetConfig)
         {
             var status = Fn.GetEncodePresetConfig(
                 this, encodeGuid, presetGuid, ref presetConfig);
             CheckResult(this, status);
         }
 
-        public NvEncPresetConfig GetEncodePresetConfig(
-            Guid encodeGuid, Guid presetGuid)
+        public NvEncPresetConfig GetEncodePresetConfig(Guid encodeGuid, Guid presetGuid)
+        {
+            var presetConfig = new NvEncPresetConfig
+            {
+                //Version = NV_ENC_PRESET_CONFIG_VER,
+                //PresetCfg = new NvEncConfig
+                //{
+                //    Version = NV_ENC_CONFIG_VER
+                //}
+            };
+
+            GetEncodePresetConfig(encodeGuid, presetGuid, ref presetConfig);
+            return presetConfig;
+        }
+
+        public void GetEncodePresetConfigEx(Guid encodeGuid, Guid presetGuid, NvEncTuningInfo tuningInfo, ref NvEncPresetConfig presetConfig)
+        {
+            var status = Fn.GetEncodePresetConfigEx(this, encodeGuid, presetGuid, (uint)tuningInfo, ref presetConfig);
+            CheckResult(this, status);
+        }
+
+        public NvEncPresetConfig GetEncodePresetConfigEx(Guid encodeGuid, Guid presetGuid, NvEncTuningInfo tuningInfo = NvEncTuningInfo.HighQuality)
         {
             var presetConfig = new NvEncPresetConfig
             {
@@ -400,7 +418,7 @@ namespace Lennox.NvEncSharp
                 }
             };
 
-            GetEncodePresetConfig(encodeGuid, presetGuid, ref presetConfig);
+            GetEncodePresetConfigEx(encodeGuid, presetGuid, tuningInfo, ref presetConfig);
             return presetConfig;
         }
 

--- a/src/NvEncSharp/Structs.cs
+++ b/src/NvEncSharp/Structs.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Runtime.InteropServices;
 
 /*******
@@ -22,6 +21,9 @@ namespace Lennox.NvEncSharp
         /// <summary>hevcConfig: [in]: Specifies the HEVC-specific encoder configuration.</summary>
         [FieldOffset(0)]
         public NvEncConfigHevc HevcConfig;
+        /// <summary>av1Config: [in]: Specifies the AV1-specific encoder configuration.</summary>
+        [FieldOffset(0)]
+        public NvEncConfigAv1 Av1Config;
         /// <summary>h264MeOnlyConfig: [in]: Specifies the H.264-specific ME only encoder configuration.</summary>
         [FieldOffset(0)]
         public NvEncConfigH264Meonly H264MeOnlyConfig;
@@ -58,6 +60,9 @@ namespace Lennox.NvEncSharp
         /// <summary>hevcPicParams: [in]: HEVC encode picture params.</summary>
         [FieldOffset(0)]
         public NvEncPicParamsHevc HevcPicParams;
+        /// <summary>av1PicParams: [in]: AV1 encode picture params.</summary>
+        [FieldOffset(0)]
+        public NvEncPicParamsAv1 Av1PicParams;
         /// <summary>reserved[256]: [in]: Reserved and must be set to 0.</summary>
         [FieldOffset(0)]
         private fixed uint Reserved[256];
@@ -92,6 +97,130 @@ namespace Lennox.NvEncSharp
         private fixed uint Reserved[62];
     }
 
+    /// <summary>NV_ENC_RESTORE_ENCODER_STATE_PARAMS
+    /// Restore encoder state parameters</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct NvEncRestoreEncoderStateParams
+    {
+        /// <summary>version: [in]: Struct version.</summary>
+        public uint Version;
+        /// <summary>bufferIdx: [in]: State buffer index to which the encoder state will be restored</summary>
+        public uint BufferIdx;
+        /// <summary>state: [in]: State type to restore</summary>
+        public NvEncStateRestoreType State;
+        /// <summary>reserved: [in]: Reserved and must be set to 0</summary>
+        private uint Reserved;
+        /// <summary>outputBitstream: [in]: Specifies the output buffer pointer, for AV1 encode only.
+        /// Application must call NvEncRestoreEncoderState() API with _NV_ENC_RESTORE_ENCODER_STATE_PARAMS::outputBitstream and
+        /// _NV_ENC_RESTORE_ENCODER_STATE_PARAMS::completionEvent as input when an earlier call to this API returned "NV_ENC_ERR_NEED_MORE_OUTPUT", for AV1 encode.</summary>
+        public NvEncOutputPtr OutputBitstream;
+        /// <summary>completionEvent: [in]: Specifies the completion event when asynchronous mode of encoding is enabled. Used for AV1 encode only.</summary>
+        public IntPtr CompletionEvent;
+        /// <summary>reserved1[64]: [in]: Reserved and must be set to 0</summary>
+        private fixed uint Reserved1[64];
+        /// <summary>reserved2[64]: [in]: Reserved and must be set to NULL</summary>
+        #region Reserved2[64]
+        private IntPtr Reserved20;
+        private IntPtr Reserved21;
+        private IntPtr Reserved22;
+        private IntPtr Reserved23;
+        private IntPtr Reserved24;
+        private IntPtr Reserved25;
+        private IntPtr Reserved26;
+        private IntPtr Reserved27;
+        private IntPtr Reserved28;
+        private IntPtr Reserved29;
+        private IntPtr Reserved210;
+        private IntPtr Reserved211;
+        private IntPtr Reserved212;
+        private IntPtr Reserved213;
+        private IntPtr Reserved214;
+        private IntPtr Reserved215;
+        private IntPtr Reserved216;
+        private IntPtr Reserved217;
+        private IntPtr Reserved218;
+        private IntPtr Reserved219;
+        private IntPtr Reserved220;
+        private IntPtr Reserved221;
+        private IntPtr Reserved222;
+        private IntPtr Reserved223;
+        private IntPtr Reserved224;
+        private IntPtr Reserved225;
+        private IntPtr Reserved226;
+        private IntPtr Reserved227;
+        private IntPtr Reserved228;
+        private IntPtr Reserved229;
+        private IntPtr Reserved230;
+        private IntPtr Reserved231;
+        private IntPtr Reserved232;
+        private IntPtr Reserved233;
+        private IntPtr Reserved234;
+        private IntPtr Reserved235;
+        private IntPtr Reserved236;
+        private IntPtr Reserved237;
+        private IntPtr Reserved238;
+        private IntPtr Reserved239;
+        private IntPtr Reserved240;
+        private IntPtr Reserved241;
+        private IntPtr Reserved242;
+        private IntPtr Reserved243;
+        private IntPtr Reserved244;
+        private IntPtr Reserved245;
+        private IntPtr Reserved246;
+        private IntPtr Reserved247;
+        private IntPtr Reserved248;
+        private IntPtr Reserved249;
+        private IntPtr Reserved250;
+        private IntPtr Reserved251;
+        private IntPtr Reserved252;
+        private IntPtr Reserved253;
+        private IntPtr Reserved254;
+        private IntPtr Reserved255;
+        private IntPtr Reserved256;
+        private IntPtr Reserved257;
+        private IntPtr Reserved258;
+        private IntPtr Reserved259;
+        private IntPtr Reserved260;
+        private IntPtr Reserved261;
+        private IntPtr Reserved262;
+        private IntPtr Reserved263;
+        #endregion Reserved2[64]
+    }
+
+    /// <summary>NV_ENC_OUTPUT_STATS_BLOCK
+    /// Encoded frame information parameters for every block.</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct NvEncOutputStatsBlock
+    {
+        /// <summary>version: [in]: Struct version</summary>
+        public uint Version;
+        /// <summary>QP: [out]: QP of the block</summary>
+        public byte QP;
+        /// <summary>reserved[3]: [in]: Reserved and must be set to 0</summary>
+        private fixed byte Reserved[3];
+        /// <summary>bitcount: [out]: Bitcount of the block</summary>
+        public uint Bitcount;
+        /// <summary>reserved1[13]: [in]: Reserved and must be set to 0</summary>
+        private fixed uint Reserved1[13];
+    }
+
+    /// <summary>NV_ENC_OUTPUT_STATS_ROW
+    /// Encoded frame information parameters for every row.</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct NvEncOutputStatsRow
+    {
+        /// <summary>version: [in]: Struct version</summary>
+        public uint Version;
+        /// <summary>QP: [out]: QP of the row</summary>
+        public byte QP;
+        /// <summary>reserved[3]: [in]: Reserved and must be set to 0</summary>
+        private fixed byte Reserved[3];
+        /// <summary>bitcount: [out]: Bitcount of the row</summary>
+        public uint Bitcount;
+        /// <summary>reserved1[13]: [in]: Reserved and must be set to 0</summary>
+        private fixed uint Reserved1[13];
+    }
+
     /// <summary>NV_ENC_ENCODE_OUT_PARAMS
     /// Encoder Output parameters</summary>
     [StructLayout(LayoutKind.Sequential)]
@@ -105,6 +234,90 @@ namespace Lennox.NvEncSharp
         private fixed uint Reserved[62];
     }
 
+    /// <summary>NV_ENC_LOOKAHEAD_PIC_PARAMS
+    /// Lookahead picture parameters</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct NvEncLookaheadPicParams
+    {
+        /// <summary>version: [in]: Struct version.</summary>
+        public uint Version;
+        /// <summary>reserved: [in]: Reserved and must be set to 0</summary>
+        private uint Reserved;
+        /// <summary>inputBuffer: [in]: Specifies the input buffer pointer. Client must use a pointer obtained from ::NvEncCreateInputBuffer() or ::NvEncMapInputResource() APIs.</summary>
+        public NvEncInputPtr InputBuffer;
+        /// <summary>pictureType: [in]: Specifies input picture type. Client required to be set explicitly by the client if the client has not set NV_ENC_INITALIZE_PARAMS::enablePTD to 1 while calling NvInitializeEncoder.</summary>
+        public NvEncPicType PictureType;
+        /// <summary>reserved1[63]: [in]: Reserved and must be set to 0</summary>
+        private fixed uint Reserved1[63];
+        /// <summary>reserved2[64]: [in]: Reserved and must be set to NULL</summary>
+        #region Reserved2[64]
+        private IntPtr Reserved20;
+        private IntPtr Reserved21;
+        private IntPtr Reserved22;
+        private IntPtr Reserved23;
+        private IntPtr Reserved24;
+        private IntPtr Reserved25;
+        private IntPtr Reserved26;
+        private IntPtr Reserved27;
+        private IntPtr Reserved28;
+        private IntPtr Reserved29;
+        private IntPtr Reserved210;
+        private IntPtr Reserved211;
+        private IntPtr Reserved212;
+        private IntPtr Reserved213;
+        private IntPtr Reserved214;
+        private IntPtr Reserved215;
+        private IntPtr Reserved216;
+        private IntPtr Reserved217;
+        private IntPtr Reserved218;
+        private IntPtr Reserved219;
+        private IntPtr Reserved220;
+        private IntPtr Reserved221;
+        private IntPtr Reserved222;
+        private IntPtr Reserved223;
+        private IntPtr Reserved224;
+        private IntPtr Reserved225;
+        private IntPtr Reserved226;
+        private IntPtr Reserved227;
+        private IntPtr Reserved228;
+        private IntPtr Reserved229;
+        private IntPtr Reserved230;
+        private IntPtr Reserved231;
+        private IntPtr Reserved232;
+        private IntPtr Reserved233;
+        private IntPtr Reserved234;
+        private IntPtr Reserved235;
+        private IntPtr Reserved236;
+        private IntPtr Reserved237;
+        private IntPtr Reserved238;
+        private IntPtr Reserved239;
+        private IntPtr Reserved240;
+        private IntPtr Reserved241;
+        private IntPtr Reserved242;
+        private IntPtr Reserved243;
+        private IntPtr Reserved244;
+        private IntPtr Reserved245;
+        private IntPtr Reserved246;
+        private IntPtr Reserved247;
+        private IntPtr Reserved248;
+        private IntPtr Reserved249;
+        private IntPtr Reserved250;
+        private IntPtr Reserved251;
+        private IntPtr Reserved252;
+        private IntPtr Reserved253;
+        private IntPtr Reserved254;
+        private IntPtr Reserved255;
+        private IntPtr Reserved256;
+        private IntPtr Reserved257;
+        private IntPtr Reserved258;
+        private IntPtr Reserved259;
+        private IntPtr Reserved260;
+        private IntPtr Reserved261;
+        private IntPtr Reserved262;
+        private IntPtr Reserved263;
+        #endregion Reserved2[64]
+    }
+
     /// <summary>NV_ENC_CREATE_INPUT_BUFFER
     /// Creation parameters for input buffer.</summary>
     [StructLayout(LayoutKind.Sequential)]
@@ -112,9 +325,9 @@ namespace Lennox.NvEncSharp
     {
         /// <summary>version: [in]: Struct version. Must be set to ::NV_ENC_CREATE_INPUT_BUFFER_VER</summary>
         public uint Version;
-        /// <summary>width: [in]: Input buffer width</summary>
+        /// <summary>width: [in]: Input frame width</summary>
         public uint Width;
-        /// <summary>height: [in]: Input buffer width</summary>
+        /// <summary>height: [in]: Input frame height</summary>
         public uint Height;
         /// <summary>memoryHeap: [in]: Deprecated. Do not use</summary>
         public NvEncMemoryHeap MemoryHeap;
@@ -124,10 +337,10 @@ namespace Lennox.NvEncSharp
         private uint Reserved;
         /// <summary>inputBuffer: [out]: Pointer to input buffer</summary>
         public NvEncInputPtr InputBuffer;
-        /// <summary>pSysMemBuffer: [in]: Pointer to existing sysmem buffer</summary>
+        /// <summary>pSysMemBuffer: [in]: Pointer to existing system memory buffer</summary>
         public IntPtr PSysMemBuffer;
-        /// <summary>reserved1[57]: [in]: Reserved and must be set to 0</summary>
-        private fixed uint Reserved1[57];
+        /// <summary>reserved1[58]: [in]: Reserved and must be set to 0</summary>
+        private fixed uint Reserved1[58];
         /// <summary>reserved2[63]: [in]: Reserved and must be set to NULL</summary>
         #region Reserved2[63]
         private IntPtr Reserved20;
@@ -289,9 +502,9 @@ namespace Lennox.NvEncSharp
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct NvEncMvector
     {
-        /// <summary>mvx: the x component of MV in qpel units</summary>
+        /// <summary>mvx: the x component of MV in quarter-pel units</summary>
         public short Mvx;
-        /// <summary>mvy: the y component of MV in qpel units</summary>
+        /// <summary>mvy: the y component of MV in quarter-pel units</summary>
         public short Mvy;
     }
 
@@ -344,10 +557,12 @@ namespace Lennox.NvEncSharp
     {
         /// <summary>version: [in]: Struct version. Must be set to NV_ENC_CREATE_MV_BUFFER_VER</summary>
         public uint Version;
+        /// <summary>reserved: [in]: Reserved and should be set to 0</summary>
+        private uint Reserved;
         /// <summary>mvBuffer: [out]: Pointer to the output motion vector buffer</summary>
         public NvEncOutputPtr MvBuffer;
-        /// <summary>reserved1[255]: [in]: Reserved and should be set to 0</summary>
-        private fixed uint Reserved1[255];
+        /// <summary>reserved1[254]: [in]: Reserved and should be set to 0</summary>
+        private fixed uint Reserved1[254];
         /// <summary>reserved2[63]: [in]: Reserved and should be set to NULL</summary>
         #region Reserved2[63]
         private IntPtr Reserved20;
@@ -430,7 +645,7 @@ namespace Lennox.NvEncSharp
     }
 
     /// <summary>NV_ENC_RC_PARAMS
-    /// Rate Control Configuration Paramters</summary>
+    /// Rate Control Configuration Parameters</summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct NvEncRcParams
     {
@@ -459,7 +674,7 @@ namespace Lennox.NvEncSharp
             get => (BitField1[0] & 2) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 2) : (byte)(BitField1[0] & -3);
         }
-        /// <summary>enableInitialRCQP: [in]: Set this to 1 if user suppplied initial QP is used for rate control.</summary>
+        /// <summary>enableInitialRCQP: [in]: Set this to 1 if user supplied initial QP is used for rate control.</summary>
         public bool EnableInitialRCQP {
             get => (BitField1[0] & 4) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 4) : (byte)(BitField1[0] & -5);
@@ -470,7 +685,7 @@ namespace Lennox.NvEncSharp
             set => BitField1[0] = value ? (byte)(BitField1[0] | 8) : (byte)(BitField1[0] & -9);
         }
         /// <summary>reservedBitField1: [in]: Reserved bitfields and must be set to 0.</summary>
-        /// <summary>enableLookahead: [in]: Set this to 1 to enable lookahead with depth `lookaheadDepth` (if lookahead is enabled, input frames must remain available to the encoder until encode completion)</summary>
+        /// <summary>enableLookahead: [in]: Set this to 1 to enable lookahead with depth <lookaheadDepth> (if lookahead is enabled, input frames must remain available to the encoder until encode completion)</summary>
         public bool EnableLookahead {
             get => (BitField1[0] & 32) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 32) : (byte)(BitField1[0] & -33);
@@ -506,48 +721,146 @@ namespace Lennox.NvEncSharp
             get => (BitField2[0] & 8) != 0;
             set => BitField2[0] = value ? (byte)(BitField2[0] | 8) : (byte)(BitField2[0] & -9);
         }
-        /// <summary>aqStrength: [in]: When AQ (Spatial) is enabled (i.e. NV_ENC_RC_PARAMS::enableAQ is set), this field is used to specify AQ strength. AQ strength scale is from 1 (low) - 15 (aggressive). If not set, strength is autoselected by driver.</summary>
+        /// <summary>aqStrength: [in]: When AQ (Spatial) is enabled (i.e. NV_ENC_RC_PARAMS::enableAQ is set), this field is used to specify AQ strength. AQ strength scale is from 1 (low) - 15 (aggressive).
+        /// If not set, strength is auto selected by driver.</summary>
         public uint AqStrength {
             get { fixed (byte* ptr = &BitField2[0]) { return ((*(uint*)ptr >> 4) & 4); } }
             set => BitField2[0] = (byte)((BitField2[0] & ~64) | (((value) << 4) & 64));
         }
         internal fixed byte BitField3[2];
+        /// <summary>enableExtLookahead: [in]: Set this to 1 to enable lookahead externally.
+        /// Application must call NvEncLookahead() for NV_ENC_RC_PARAMS::lookaheadDepth number of frames,
+        /// before calling NvEncEncodePicture() for the first frame</summary>
+        public bool EnableExtLookahead {
+            get => (BitField3[0] & 1) != 0;
+            set => BitField3[0] = value ? (byte)(BitField3[0] | 1) : (byte)(BitField3[0] & -2);
+        }
         /// <summary>reservedBitFields: [in]: Reserved bitfields and must be set to 0</summary>
         /// <summary>minQP: [in]: Specifies the minimum QP used for rate control. Client must set NV_ENC_CONFIG::enableMinQP to 1.</summary>
         public NvEncQp MinQP;
         /// <summary>maxQP: [in]: Specifies the maximum QP used for rate control. Client must set NV_ENC_CONFIG::enableMaxQP to 1.</summary>
         public NvEncQp MaxQP;
-        /// <summary>initialRCQP: [in]: Specifies the initial QP used for rate control. Client must set NV_ENC_CONFIG::enableInitialRCQP to 1.</summary>
+        /// <summary>initialRCQP: [in]: Specifies the initial QP hint used for rate control. The parameter is just used as hint to influence the QP difference between I,P and B frames.
+        /// Client must set NV_ENC_CONFIG::enableInitialRCQP to 1.</summary>
         public NvEncQp InitialRCQP;
-        /// <summary>temporallayerIdxMask: [in]: Specifies the temporal layers (as a bitmask) whose QPs have changed. Valid max bitmask is [2^NV_ENC_CAPS_NUM_MAX_TEMPORAL_LAYERS - 1]</summary>
+        /// <summary>temporallayerIdxMask: [in]: Specifies the temporal layers (as a bitmask) whose QPs have changed. Valid max bitmask is [2^NV_ENC_CAPS_NUM_MAX_TEMPORAL_LAYERS - 1].
+        /// Applicable only for constant QP mode (NV_ENC_RC_PARAMS::rateControlMode = NV_ENC_PARAMS_RC_CONSTQP).</summary>
         public uint TemporallayerIdxMask;
-        /// <summary>temporalLayerQP[8]: [in]: Specifies the temporal layer QPs used for rate control. Temporal layer index is used as as the array index</summary>
+        /// <summary>temporalLayerQP[8]: [in]: Specifies the temporal layer QPs used for rate control. Temporal layer index is used as the array index.
+        /// Applicable only for constant QP mode (NV_ENC_RC_PARAMS::rateControlMode = NV_ENC_PARAMS_RC_CONSTQP).</summary>
         public fixed byte TemporalLayerQP[8];
         /// <summary>targetQuality: [in]: Target CQ (Constant Quality) level for VBR mode (range 0-51 with 0-automatic)</summary>
         public byte TargetQuality;
         /// <summary>targetQualityLSB: [in]: Fractional part of target quality (as 8.8 fixed point format)</summary>
         public byte TargetQualityLSB;
-        /// <summary>lookaheadDepth: [in]: Maximum depth of lookahead with range 0-32 (only used if enableLookahead=1)</summary>
+        /// <summary>lookaheadDepth: [in]: Maximum depth of lookahead with range 0-(31 - number of B frames).
+        /// lookaheadDepth is only used if enableLookahead=1.</summary>
         public ushort LookaheadDepth;
-        /// <summary>reserved1</summary>
-        private uint Reserved1;
+        /// <summary>lowDelayKeyFrameScale: [in]: Specifies the ratio of I frame bits to P frame bits in case of single frame VBV and CBR rate control mode,
+        /// is set to 2 by default for low latency tuning info and 1 by default for ultra low latency tuning info</summary>
+        public byte LowDelayKeyFrameScale;
+        /// <summary>yDcQPIndexOffset: [in]: Specifies the value of 'deltaQ_y_dc' in AV1.</summary>
+        public byte YDcQPIndexOffset;
+        /// <summary>uDcQPIndexOffset: [in]: Specifies the value of 'deltaQ_u_dc' in AV1.</summary>
+        public byte UDcQPIndexOffset;
+        /// <summary>vDcQPIndexOffset: [in]: Specifies the value of 'deltaQ_v_dc' in AV1 (for future use only - deltaQ_v_dc is currently always internally set to same value as deltaQ_u_dc).</summary>
+        public byte VDcQPIndexOffset;
         /// <summary>qpMapMode: [in]: This flag is used to interpret values in array specified by NV_ENC_PIC_PARAMS::qpDeltaMap.
         /// Set this to NV_ENC_QP_MAP_EMPHASIS to treat values specified by NV_ENC_PIC_PARAMS::qpDeltaMap as Emphasis Level Map.
         /// Emphasis Level can be assigned any value specified in enum NV_ENC_EMPHASIS_MAP_LEVEL.
         /// Emphasis Level Map is used to specify regions to be encoded at varying levels of quality.
         /// The hardware encoder adjusts the quantization within the image as per the provided emphasis map,
-        /// by adjusting the quantization parameter (QP) assigned to each macroblock. This adjustment is commonly called “Delta QP”.
-        /// The adjustment depends on the absolute QP decided by the rate control algorithm, and is applied after the rate control has decided each macroblock’s QP.
+        /// by adjusting the quantization parameter (QP) assigned to each macroblock. This adjustment is commonly called "Delta QP".
+        /// The adjustment depends on the absolute QP decided by the rate control algorithm, and is applied after the rate control has decided each macroblock's QP.
         /// Since the Delta QP overrides rate control, enabling Emphasis Level Map may violate bitrate and VBV buffer size constraints.
         /// Emphasis Level Map is useful in situations where client has a priori knowledge of the image complexity (e.g. via use of NVFBC's Classification feature) and encoding those high-complexity areas at higher quality (lower QP) is important, even at the possible cost of violating bitrate/VBV buffer size constraints
         /// This feature is not supported when AQ( Spatial/Temporal) is enabled.
         /// This feature is only supported for H264 codec currently.
-        /// Set this to NV_ENC_QP_MAP_DELTA to treat values specified by NV_ENC_PIC_PARAMS::qpDeltaMap as QPDelta. This specifies QP modifier to be applied on top of the QP chosen by rate control
+        /// Set this to NV_ENC_QP_MAP_DELTA to treat values specified by NV_ENC_PIC_PARAMS::qpDeltaMap as QP Delta. This specifies QP modifier to be applied on top of the QP chosen by rate control
         /// Set this to NV_ENC_QP_MAP_DISABLED to ignore NV_ENC_PIC_PARAMS::qpDeltaMap values. In this case, qpDeltaMap should be set to NULL.
         /// Other values are reserved for future use.</summary>
         public NvEncQpMapMode QpMapMode;
-        /// <summary>reserved[7]</summary>
-        private fixed uint Reserved[7];
+        /// <summary>multiPass: [in]: This flag is used to enable multi-pass encoding for a given ::NV_ENC_PARAMS_RC_MODE. This flag is not valid for H264 and HEVC MEOnly mode</summary>
+        public NvEncMultiPass MultiPass;
+        /// <summary>alphaLayerBitrateRatio: [in]: Specifies the ratio in which bitrate should be split between base and alpha layer. A value 'x' for this field will split the target bitrate in a ratio of x : 1 between base and alpha layer.
+        /// The default split ratio is 15.</summary>
+        public uint AlphaLayerBitrateRatio;
+        /// <summary>cbQPIndexOffset: [in]: Specifies the value of 'chroma_qp_index_offset' in H264 / 'pps_cb_qp_offset' in HEVC / 'deltaQ_u_ac' in AV1.</summary>
+        public byte CbQPIndexOffset;
+        /// <summary>crQPIndexOffset: [in]: Specifies the value of 'second_chroma_qp_index_offset' in H264 / 'pps_cr_qp_offset' in HEVC / 'deltaQ_v_ac' in AV1 (for future use only - deltaQ_v_ac is currently always internally set to same value as deltaQ_u_ac).</summary>
+        public byte CrQPIndexOffset;
+        /// <summary>reserved2</summary>
+        private ushort Reserved2;
+        /// <summary>lookaheadLevel: [in]: Specifies the lookahead level. Higher level may improve quality at the expense of performance.</summary>
+        public NvEncLookaheadLevel LookaheadLevel;
+        /// <summary>reserved[3]</summary>
+        private fixed uint Reserved[3];
+    }
+
+    /// <summary>NV_ENC_CLOCK_TIMESTAMP_SET
+    /// Clock Timestamp set parameters
+    /// For H264, this structure is used to populate Picture Timing SEI when NV_ENC_CONFIG_H264::enableTimeCode is set to 1.
+    /// For HEVC, this structure is used to populate Time Code SEI when NV_ENC_CONFIG_HEVC::enableTimeCodeSEI is set to 1.
+    /// For more details, refer to Annex D of ITU-T Specification.</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct NvEncClockTimestampSet
+    {
+        internal fixed byte BitField1[4];
+        /// <summary>countingType: [in] Specifies the 'counting_type'</summary>
+        public bool CountingType {
+            get => (BitField1[0] & 1) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 1) : (byte)(BitField1[0] & -2);
+        }
+        /// <summary>discontinuityFlag: [in] Specifies the 'discontinuity_flag'</summary>
+        public bool DiscontinuityFlag {
+            get => (BitField1[0] & 2) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 2) : (byte)(BitField1[0] & -3);
+        }
+        /// <summary>cntDroppedFrames: [in] Specifies the 'cnt_dropped_flag'</summary>
+        public bool CntDroppedFrames {
+            get => (BitField1[0] & 4) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 4) : (byte)(BitField1[0] & -5);
+        }
+        /// <summary>nFrames: [in] Specifies the value of 'n_frames'</summary>
+        public uint NFrames {
+            get { fixed (byte* ptr = &BitField1[0]) { return ((*(uint*)ptr >> 3) & 8); } }
+            set => BitField1[0] = (byte)((BitField1[0] & ~64) | (((value) << 3) & 64));
+        }
+        /// <summary>secondsValue: [in] Specifies the 'seconds_value'</summary>
+        public uint SecondsValue {
+            get { fixed (byte* ptr = &BitField1[1]) { return ((*(uint*)ptr >> 3) & 6); } }
+            set => BitField1[1] = (byte)((BitField1[1] & ~12288) | (((value) << 3) & 48));
+        }
+        /// <summary>minutesValue: [in] Specifies the 'minutes_value'</summary>
+        public uint MinutesValue {
+            get { fixed (byte* ptr = &BitField1[2]) { return ((*(uint*)ptr >> 1) & 6); } }
+            set => BitField1[2] = (byte)((BitField1[2] & ~786432) | (((value) << 1) & 12));
+        }
+        /// <summary>hoursValue: [in] Specifies the 'hours_value'</summary>
+        public uint HoursValue {
+            get { fixed (byte* ptr = &BitField1[2]) { return ((*(uint*)ptr >> 7) & 5); } }
+            set => BitField1[2] = (byte)((BitField1[2] & ~41943040) | (((value) << 7) & 640));
+        }
+        /// <summary>reserved2: [in] Reserved and must be set to 0</summary>
+        /// <summary>timeOffset: [in] Specifies the 'time_offset_value'</summary>
+        public uint TimeOffset;
+    }
+
+    /// <summary>NV_ENC_TIME_CODE</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct NvEncTimeCode
+    {
+        /// <summary>displayPicStruct: [in] Display picStruct</summary>
+        public NvEncDisplayPicStruct DisplayPicStruct;
+        /// <summary>clockTimestamp[MAX_NUM_CLOCK_TS]: [in] Clock Timestamp set</summary>
+        public NvEncClockTimestampSet ClockTimestamp0;
+        public NvEncClockTimestampSet ClockTimestamp1;
+        public NvEncClockTimestampSet ClockTimestamp2;
+
+        /// <summary>skipClockTimestampInsertion: [in] 0 : Inserts Clock Timestamp if NV_ENC_CONFIG_H264::enableTimeCode (H264) or
+        /// NV_ENC_CONFIG_HEVC::outputTimeCodeSEI (HEVC) is specified
+        /// 1 : Skips insertion of Clock Timestamp for current frame</summary>
+        public uint SkipClockTimestampInsertion;
     }
 
     /// <summary>NV_ENC_CONFIG_H264_VUI_PARAMETERS
@@ -556,66 +869,78 @@ namespace Lennox.NvEncSharp
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct NvEncConfigH264VuiParameters
     {
-        /// <summary>overscanInfoPresentFlag: [in]: if set to 1 , it specifies that the overscanInfo is present</summary>
+        /// <summary>overscanInfoPresentFlag: [in]: If set to 1 , it specifies that the overscanInfo is present</summary>
         public uint OverscanInfoPresentFlag;
         /// <summary>overscanInfo: [in]: Specifies the overscan info(as defined in Annex E of the ITU-T Specification).</summary>
         public uint OverscanInfo;
         /// <summary>videoSignalTypePresentFlag: [in]: If set to 1, it specifies that the videoFormat, videoFullRangeFlag and colourDescriptionPresentFlag are present.</summary>
         public uint VideoSignalTypePresentFlag;
         /// <summary>videoFormat: [in]: Specifies the source video format(as defined in Annex E of the ITU-T Specification).</summary>
-        public uint VideoFormat;
+        public NvEncVuiVideoFormat VideoFormat;
         /// <summary>videoFullRangeFlag: [in]: Specifies the output range of the luma and chroma samples(as defined in Annex E of the ITU-T Specification).</summary>
         public uint VideoFullRangeFlag;
         /// <summary>colourDescriptionPresentFlag: [in]: If set to 1, it specifies that the colourPrimaries, transferCharacteristics and colourMatrix are present.</summary>
         public uint ColourDescriptionPresentFlag;
         /// <summary>colourPrimaries: [in]: Specifies color primaries for converting to RGB(as defined in Annex E of the ITU-T Specification)</summary>
-        public uint ColourPrimaries;
+        public NvEncVuiColorPrimaries ColourPrimaries;
         /// <summary>transferCharacteristics: [in]: Specifies the opto-electronic transfer characteristics to use (as defined in Annex E of the ITU-T Specification)</summary>
-        public uint TransferCharacteristics;
+        public NvEncVuiTransferCharacteristic TransferCharacteristics;
         /// <summary>colourMatrix: [in]: Specifies the matrix coefficients used in deriving the luma and chroma from the RGB primaries (as defined in Annex E of the ITU-T Specification).</summary>
-        public uint ColourMatrix;
-        /// <summary>chromaSampleLocationFlag: [in]: if set to 1 , it specifies that the chromaSampleLocationTop and chromaSampleLocationBot are present.</summary>
+        public NvEncVuiMatrixCoeffs ColourMatrix;
+        /// <summary>chromaSampleLocationFlag: [in]: If set to 1 , it specifies that the chromaSampleLocationTop and chromaSampleLocationBot are present.</summary>
         public uint ChromaSampleLocationFlag;
         /// <summary>chromaSampleLocationTop: [in]: Specifies the chroma sample location for top field(as defined in Annex E of the ITU-T Specification)</summary>
         public uint ChromaSampleLocationTop;
         /// <summary>chromaSampleLocationBot: [in]: Specifies the chroma sample location for bottom field(as defined in Annex E of the ITU-T Specification)</summary>
         public uint ChromaSampleLocationBot;
-        /// <summary>bitstreamRestrictionFlag: [in]: if set to 1, it specifies the bitstream restriction parameters are present in the bitstream.</summary>
+        /// <summary>bitstreamRestrictionFlag: [in]: If set to 1, it specifies the bitstream restriction parameters are present in the bitstream.</summary>
         public uint BitstreamRestrictionFlag;
-        /// <summary>reserved[15]</summary>
-        private fixed uint Reserved[15];
+        /// <summary>timingInfoPresentFlag: [in]: If set to 1, it specifies that the timingInfo is present and the 'numUnitInTicks' and 'timeScale' fields are specified by the application.</summary>
+        public uint TimingInfoPresentFlag;
+        /// <summary>numUnitInTicks: [in]: If not set, the timingInfo may still be present with timing related fields calculated internally basedon the frame rate specified by the application.</summary>
+        public uint NumUnitInTicks;
+        /// <summary>timeScale: [in]: Specifies the number of time units of the clock(as defined in Annex E of the ITU-T Specification).</summary>
+        public uint TimeScale;
+        /// <summary>reserved[12]: [in]: Specifies the frquency of the clock(as defined in Annex E of the ITU-T Specification).</summary>
+        private fixed uint Reserved[12];
     }
 
     /// <summary>NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE
     /// struct _NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE
     /// External motion vector hint counts per block type.
-    /// H264 supports multiple hint while HEVC supports one hint for each valid candidate.</summary>
+    /// H264 and AV1 support multiple hint while HEVC supports one hint for each valid candidate.</summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct NvEncExternalMeHintCountsPerBlocktype
     {
         internal fixed byte BitField1[1];
-        /// <summary>numCandsPerBlk16x16: [in]: Supported for H264,HEVC.It Specifies the number of candidates per 16x16 block.</summary>
+        /// <summary>numCandsPerBlk16x16: [in]: Supported for H264, HEVC. It Specifies the number of candidates per 16x16 block.</summary>
         public uint NumCandsPerBlk16x16 {
             get { fixed (byte* ptr = &BitField1[0]) { return ((*(uint*)ptr >> 0) & 4); } }
             set => BitField1[0] = (byte)((BitField1[0] & ~4) | (((value) << 0) & 4));
         }
-        /// <summary>numCandsPerBlk16x8: [in]: Supported for H264 only.Specifies the number of candidates per 16x8 block.</summary>
+        /// <summary>numCandsPerBlk16x8: [in]: Supported for H264 only. Specifies the number of candidates per 16x8 block.</summary>
         public uint NumCandsPerBlk16x8 {
             get { fixed (byte* ptr = &BitField1[0]) { return ((*(uint*)ptr >> 4) & 4); } }
             set => BitField1[0] = (byte)((BitField1[0] & ~64) | (((value) << 4) & 64));
         }
         internal fixed byte BitField2[1];
-        /// <summary>numCandsPerBlk8x16: [in]: Supported for H264 only.Specifies the number of candidates per 8x16 block.</summary>
+        /// <summary>numCandsPerBlk8x16: [in]: Supported for H264 only. Specifies the number of candidates per 8x16 block.</summary>
         public uint NumCandsPerBlk8x16 {
             get { fixed (byte* ptr = &BitField2[0]) { return ((*(uint*)ptr >> 0) & 4); } }
             set => BitField2[0] = (byte)((BitField2[0] & ~4) | (((value) << 0) & 4));
         }
-        /// <summary>numCandsPerBlk8x8: [in]: Supported for H264,HEVC.Specifies the number of candidates per 8x8 block.</summary>
+        /// <summary>numCandsPerBlk8x8: [in]: Supported for H264, HEVC. Specifies the number of candidates per 8x8 block.</summary>
         public uint NumCandsPerBlk8x8 {
             get { fixed (byte* ptr = &BitField2[0]) { return ((*(uint*)ptr >> 4) & 4); } }
             set => BitField2[0] = (byte)((BitField2[0] & ~64) | (((value) << 4) & 64));
         }
-        internal fixed byte BitField3[2];
+        internal fixed byte BitField3[1];
+        /// <summary>numCandsPerSb: [in]: Supported for AV1 only. Specifies the number of candidates per SB.</summary>
+        public uint NumCandsPerSb {
+            get { fixed (byte* ptr = &BitField3[0]) { return ((*(uint*)ptr >> 0) & 8); } }
+            set => BitField3[0] = (byte)((BitField3[0] & ~8) | (((value) << 0) & 8));
+        }
+        internal fixed byte BitField4[1];
         /// <summary>reserved: [in]: Reserved for padding.</summary>
         /// <summary>reserved1[3]: [in]: Reserved for future use.</summary>
         private fixed uint Reserved1[3];
@@ -623,7 +948,7 @@ namespace Lennox.NvEncSharp
 
     /// <summary>NVENC_EXTERNAL_ME_HINT
     /// struct _NVENC_EXTERNAL_ME_HINT
-    /// External Motion Vector hint structure.</summary>
+    /// External Motion Vector hint structure for H264 and HEVC.</summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct NvEncExternalMeHint
     {
@@ -671,6 +996,80 @@ namespace Lennox.NvEncSharp
         }
     }
 
+    /// <summary>NVENC_EXTERNAL_ME_SB_HINT
+    /// struct _NVENC_EXTERNAL_ME_SB_HINT
+    /// External Motion Vector SB hint structure for AV1</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct NvEncExternalMeSbHint
+    {
+        internal fixed byte BitField1[2];
+        /// <summary>refidx: [in]: Specifies the reference index (31=invalid)</summary>
+        public short Refidx {
+            get { fixed (byte* ptr = &BitField1[0]) { return (short)((*(short*)ptr >> 0) & 5); } }
+            set => BitField1[0] = (byte)((BitField1[0] & ~5) | (((value) << 0) & 5));
+        }
+        /// <summary>direction: [in]: Specifies the direction of motion estimation . 0=L0 1=L1.</summary>
+        public bool Direction {
+            get => (BitField1[0] & 32) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 32) : (byte)(BitField1[0] & -33);
+        }
+        /// <summary>bi: [in]: Specifies reference mode 0=single mv, 1=compound mv</summary>
+        public bool Bi {
+            get => (BitField1[0] & 64) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 64) : (byte)(BitField1[0] & -65);
+        }
+        /// <summary>partition_type: [in]: Specifies the partition type: 0: 2NX2N, 1:2NxN, 2:Nx2N. reserved 3bits for future modes</summary>
+        public short Partition_type {
+            get { fixed (byte* ptr = &BitField1[0]) { return (short)((*(short*)ptr >> 7) & 3); } }
+            set => BitField1[0] = (byte)((BitField1[0] & ~384) | (((value) << 7) & 384));
+        }
+        /// <summary>x8: [in]: Specifies the current partition's top left x position in 8 pixel unit</summary>
+        public short X8 {
+            get { fixed (byte* ptr = &BitField1[1]) { return (short)((*(short*)ptr >> 2) & 3); } }
+            set => BitField1[1] = (byte)((BitField1[1] & ~3072) | (((value) << 2) & 12));
+        }
+        /// <summary>last_of_cu: [in]: Set to 1 for the last MV current CU</summary>
+        public bool Last_of_cu {
+            get => (BitField1[1] & 8192) != 0;
+            set => BitField1[1] = value ? (byte)(BitField1[1] | 8192) : (byte)(BitField1[1] & -8193);
+        }
+        /// <summary>last_of_sb: [in]: Set to 1 for the last MV of current SB</summary>
+        public bool Last_of_sb {
+            get => (BitField1[1] & 16384) != 0;
+            set => BitField1[1] = value ? (byte)(BitField1[1] | 16384) : (byte)(BitField1[1] & -16385);
+        }
+        /// <summary>reserved0: [in]: Reserved and must be set to 0</summary>
+        internal fixed byte BitField2[2];
+        /// <summary>mvx: [in]: Specifies the x component of integer pixel MV (relative to current MB) S12.2.</summary>
+        public short Mvx {
+            get { fixed (byte* ptr = &BitField2[0]) { return (short)((*(short*)ptr >> 0) & 14); } }
+            set {
+                BitField2[0] = (byte)((BitField2[0] & ~6) | (((value) << 0) & 6));
+                BitField2[0] = (byte)((BitField2[0] & ~512) | (((value) << 6) & 512));
+            }
+        }
+        /// <summary>cu_size: [in]: Specifies the CU size: 0: 8x8, 1: 16x16, 2:32x32, 3:64x64</summary>
+        public short Cu_size {
+            get { fixed (byte* ptr = &BitField2[1]) { return (short)((*(short*)ptr >> 6) & 2); } }
+            set => BitField2[1] = (byte)((BitField2[1] & ~32768) | (((value) << 6) & 128));
+        }
+        internal fixed byte BitField3[2];
+        /// <summary>mvy: [in]: Specifies the y component of integer pixel MV (relative to current MB) S10.2 .</summary>
+        public short Mvy {
+            get { fixed (byte* ptr = &BitField3[0]) { return (short)((*(short*)ptr >> 0) & 12); } }
+            set {
+                BitField3[0] = (byte)((BitField3[0] & ~4) | (((value) << 0) & 4));
+                BitField3[0] = (byte)((BitField3[0] & ~128) | (((value) << 4) & 128));
+            }
+        }
+        /// <summary>y8: [in]: Specifies the current partition's top left y position in 8 pixel unit</summary>
+        public short Y8 {
+            get { fixed (byte* ptr = &BitField3[1]) { return (short)((*(short*)ptr >> 4) & 3); } }
+            set => BitField3[1] = (byte)((BitField3[1] & ~12288) | (((value) << 4) & 48));
+        }
+        /// <summary>reserved1: [in]: Reserved and must be set to 0</summary>
+    }
+
     /// <summary>NV_ENC_CONFIG_H264
     /// struct _NV_ENC_CONFIG_H264
     /// H264 encoder configuration parameters</summary>
@@ -678,18 +1077,22 @@ namespace Lennox.NvEncSharp
     public unsafe struct NvEncConfigH264
     {
         internal fixed byte BitField1[1];
-        /// <summary>reserved: [in]: Reserved and must be set to 0</summary>
+        /// <summary>enableTemporalSVC: [in]: Set to 1 to enable SVC temporal</summary>
+        public bool EnableTemporalSVC {
+            get => (BitField1[0] & 1) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 1) : (byte)(BitField1[0] & -2);
+        }
         /// <summary>enableStereoMVC: [in]: Set to 1 to enable stereo MVC</summary>
         public bool EnableStereoMVC {
             get => (BitField1[0] & 2) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 2) : (byte)(BitField1[0] & -3);
         }
-        /// <summary>hierarchicalPFrames: [in]: Set to 1 to enable hierarchical PFrames</summary>
+        /// <summary>hierarchicalPFrames: [in]: Set to 1 to enable hierarchical P Frames</summary>
         public bool HierarchicalPFrames {
             get => (BitField1[0] & 4) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 4) : (byte)(BitField1[0] & -5);
         }
-        /// <summary>hierarchicalBFrames: [in]: Set to 1 to enable hierarchical BFrames</summary>
+        /// <summary>hierarchicalBFrames: [in]: Set to 1 to enable hierarchical B Frames</summary>
         public bool HierarchicalBFrames {
             get => (BitField1[0] & 8) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 8) : (byte)(BitField1[0] & -9);
@@ -699,8 +1102,7 @@ namespace Lennox.NvEncSharp
             get => (BitField1[0] & 16) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 16) : (byte)(BitField1[0] & -17);
         }
-        /// <summary>outputPictureTimingSEI: [in]: Set to 1 to write SEI picture timing syntax in the bitstream. When set for following rateControlMode : NV_ENC_PARAMS_RC_CBR, NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ,
-        /// NV_ENC_PARAMS_RC_CBR_HQ, filler data is inserted if needed to achieve hrd bitrate</summary>
+        /// <summary>outputPictureTimingSEI: [in]: Set to 1 to write SEI picture timing syntax in the bitstream.</summary>
         public bool OutputPictureTimingSEI {
             get => (BitField1[0] & 32) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 32) : (byte)(BitField1[0] & -33);
@@ -731,7 +1133,8 @@ namespace Lennox.NvEncSharp
             get => (BitField2[0] & 4) != 0;
             set => BitField2[0] = value ? (byte)(BitField2[0] | 4) : (byte)(BitField2[0] & -5);
         }
-        /// <summary>enableConstrainedEncoding: [in]: Set this to 1 to enable constrainedFrame encoding where each slice in the constarined picture is independent of other slices
+        /// <summary>enableConstrainedEncoding: [in]: Set this to 1 to enable constrainedFrame encoding where each slice in the constrained picture is independent of other slices.
+        /// Constrained encoding works only with rectangular slices.
         /// Check support for constrained encoding using ::NV_ENC_CAPS_SUPPORT_CONSTRAINED_ENCODING caps.</summary>
         public bool EnableConstrainedEncoding {
             get => (BitField2[0] & 8) != 0;
@@ -742,7 +1145,8 @@ namespace Lennox.NvEncSharp
             get => (BitField2[0] & 16) != 0;
             set => BitField2[0] = value ? (byte)(BitField2[0] | 16) : (byte)(BitField2[0] & -17);
         }
-        /// <summary>enableVFR: [in]: Set to 1 to enable variable frame rate.</summary>
+        /// <summary>enableVFR: [in]: Setting enableVFR=1 currently only sets the fixed_frame_rate_flag=0 in the VUI but otherwise
+        /// has no impact on the encoder behavior. For more details please refer to E.1 VUI syntax of H.264 standard. Note, however, that NVENC does not support VFR encoding and rate control.</summary>
         public bool EnableVFR {
             get => (BitField2[0] & 32) != 0;
             set => BitField2[0] = value ? (byte)(BitField2[0] | 32) : (byte)(BitField2[0] & -33);
@@ -771,9 +1175,7 @@ namespace Lennox.NvEncSharp
             set => BitField3[0] = value ? (byte)(BitField3[0] | 1) : (byte)(BitField3[0] & -2);
         }
         /// <summary>enableFillerDataInsertion: [in]: Set to 1 to enable insertion of filler data in the bitstream.
-        /// This flag will take effect only when one of the CBR rate
-        /// control modes (NV_ENC_PARAMS_RC_CBR, NV_ENC_PARAMS_RC_CBR_HQ,
-        /// NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ) is in use and both
+        /// This flag will take effect only when CBR rate control mode is in use and both
         /// NV_ENC_INITIALIZE_PARAMS::frameRateNum and
         /// NV_ENC_INITIALIZE_PARAMS::frameRateDen are set to non-zero
         /// values. Setting this field when
@@ -784,6 +1186,30 @@ namespace Lennox.NvEncSharp
             get => (BitField3[0] & 2) != 0;
             set => BitField3[0] = value ? (byte)(BitField3[0] | 2) : (byte)(BitField3[0] & -3);
         }
+        /// <summary>disableSVCPrefixNalu: [in]: Set to 1 to disable writing of SVC Prefix NALU preceding each slice in bitstream.
+        /// Applicable only when temporal SVC is enabled (NV_ENC_CONFIG_H264::enableTemporalSVC = 1).</summary>
+        public bool DisableSVCPrefixNalu {
+            get => (BitField3[0] & 4) != 0;
+            set => BitField3[0] = value ? (byte)(BitField3[0] | 4) : (byte)(BitField3[0] & -5);
+        }
+        /// <summary>enableScalabilityInfoSEI: [in]: Set to 1 to enable writing of Scalability Information SEI message preceding each IDR picture in bitstream
+        /// Applicable only when temporal SVC is enabled (NV_ENC_CONFIG_H264::enableTemporalSVC = 1).</summary>
+        public bool EnableScalabilityInfoSEI {
+            get => (BitField3[0] & 8) != 0;
+            set => BitField3[0] = value ? (byte)(BitField3[0] | 8) : (byte)(BitField3[0] & -9);
+        }
+        /// <summary>singleSliceIntraRefresh: [in]: Set to 1 to maintain single slice in frames during intra refresh.
+        /// Check support for single slice intra refresh using ::NV_ENC_CAPS_SINGLE_SLICE_INTRA_REFRESH caps.
+        /// This flag will be ignored if the value returned for ::NV_ENC_CAPS_SINGLE_SLICE_INTRA_REFRESH caps is false.</summary>
+        public bool SingleSliceIntraRefresh {
+            get => (BitField3[0] & 16) != 0;
+            set => BitField3[0] = value ? (byte)(BitField3[0] | 16) : (byte)(BitField3[0] & -17);
+        }
+        /// <summary>enableTimeCode: [in]: Set to 1 to enable writing of clock timestamp sets in picture timing SEI. Note that this flag will be ignored for D3D12 interface.</summary>
+        public bool EnableTimeCode {
+            get => (BitField3[0] & 32) != 0;
+            set => BitField3[0] = value ? (byte)(BitField3[0] | 32) : (byte)(BitField3[0] & -33);
+        }
         /// <summary>reservedBitFields: [in]: Reserved bitfields and must be set to 0</summary>
         /// <summary>level: [in]: Specifies the encoding level. Client is recommended to set this to NV_ENC_LEVEL_AUTOSELECT in order to enable the NvEncodeAPI interface to select the correct level.</summary>
         public uint Level;
@@ -791,9 +1217,13 @@ namespace Lennox.NvEncSharp
         public uint IdrPeriod;
         /// <summary>separateColourPlaneFlag: [in]: Set to 1 to enable 4:4:4 separate colour planes</summary>
         public uint SeparateColourPlaneFlag;
-        /// <summary>disableDeblockingFilterIDC: [in]: Specifies the deblocking filter mode. Permissible value range: [0,2]</summary>
+        /// <summary>disableDeblockingFilterIDC: [in]: Specifies the deblocking filter mode. Permissible value range: [0,2]. This flag corresponds
+        /// to the flag disable_deblocking_filter_idc specified in section 7.4.3 of H.264 specification,
+        /// which specifies whether the operation of the deblocking filter shall be disabled across some
+        /// block edges of the slice and specifies for which edges the filtering is disabled. See section
+        /// 7.4.3 of H.264 specification for more details.</summary>
         public uint DisableDeblockingFilterIDC;
-        /// <summary>numTemporalLayers: [in]: Specifies max temporal layers to be used for hierarchical coding. Valid value range is [1,::NV_ENC_CAPS_NUM_MAX_TEMPORAL_LAYERS]</summary>
+        /// <summary>numTemporalLayers: [in]: Specifies number of temporal layers to be used for hierarchical coding / temporal SVC. Valid value range is [1,::NV_ENC_CAPS_NUM_MAX_TEMPORAL_LAYERS]</summary>
         public uint NumTemporalLayers;
         /// <summary>spsId: [in]: Specifies the SPS id of the sequence header</summary>
         public uint SpsId;
@@ -807,14 +1237,14 @@ namespace Lennox.NvEncSharp
         public NvEncH264BdirectMode BdirectMode;
         /// <summary>entropyCodingMode: [in]: Specifies the entropy coding mode. Check support for CABAC mode using ::NV_ENC_CAPS_SUPPORT_CABAC caps.</summary>
         public NvEncH264EntropyCodingMode EntropyCodingMode;
-        /// <summary>stereoMode: [in]: Specifies the stereo frame packing mode which is to be signalled in frame packing arrangement SEI</summary>
+        /// <summary>stereoMode: [in]: Specifies the stereo frame packing mode which is to be signaled in frame packing arrangement SEI</summary>
         public NvEncStereoPackingMode StereoMode;
         /// <summary>intraRefreshPeriod: [in]: Specifies the interval between successive intra refresh if enableIntrarefresh is set. Requires enableIntraRefresh to be set.
         /// Will be disabled if NV_ENC_CONFIG::gopLength is not set to NVENC_INFINITE_GOPLENGTH.</summary>
         public uint IntraRefreshPeriod;
         /// <summary>intraRefreshCnt: [in]: Specifies the length of intra refresh in number of frames for periodic intra refresh. This value should be smaller than intraRefreshPeriod</summary>
         public uint IntraRefreshCnt;
-        /// <summary>maxNumRefFrames: [in]: Specifies the DPB size used for encoding. Setting it to 0 will let driver use the default dpb size.
+        /// <summary>maxNumRefFrames: [in]: Specifies the DPB size used for encoding. Setting it to 0 will let driver use the default DPB size.
         /// The low latency application which wants to invalidate reference frame as an error resilience tool
         /// is recommended to use a large DPB size so that the encoder can keep old reference frames which can be used if recent
         /// frames are invalidated.</summary>
@@ -830,7 +1260,7 @@ namespace Lennox.NvEncSharp
         /// sliceMode = 2, sliceModeData specifies # of MB rows in each slice (except last slice)
         /// sliceMode = 3, sliceModeData specifies number of slices in the picture. Driver will divide picture into slices optimally</summary>
         public uint SliceModeData;
-        /// <summary>h264VUIParameters: [in]: Specifies the H264 video usability info pamameters</summary>
+        /// <summary>h264VUIParameters: [in]: Specifies the H264 video usability info parameters</summary>
         public NvEncConfigH264VuiParameters H264VUIParameters;
         /// <summary>ltrNumFrames: [in]: Specifies the number of LTR frames. This parameter has different meaning in two LTR modes.
         /// In "LTR Trust" mode (ltrTrustMode = 1), encoder will mark the first ltrNumFrames base layer reference frames within each IDR interval as LTR.
@@ -844,7 +1274,9 @@ namespace Lennox.NvEncSharp
         /// <summary>chromaFormatIDC: [in]: Specifies the chroma format. Should be set to 1 for yuv420 input, 3 for yuv444 input.
         /// Check support for YUV444 encoding using ::NV_ENC_CAPS_SUPPORT_YUV444_ENCODE caps.</summary>
         public uint ChromaFormatIDC;
-        /// <summary>maxTemporalLayers: [in]: Specifies the max temporal layer used for hierarchical coding.</summary>
+        /// <summary>maxTemporalLayers: [in]: Specifies the max temporal layer used for temporal SVC / hierarchical coding.
+        /// Defaut value of this field is NV_ENC_CAPS::NV_ENC_CAPS_NUM_MAX_TEMPORAL_LAYERS. Note that the value NV_ENC_CONFIG_H264::maxNumRefFrames should
+        /// be greater than or equal to (NV_ENC_CONFIG_H264::maxTemporalLayers - 2) * 2, for NV_ENC_CONFIG_H264::maxTemporalLayers >= 2.</summary>
         public uint MaxTemporalLayers;
         /// <summary>useBFramesAsRef: [in]: Specifies the B-Frame as reference mode. Check support for useBFramesAsRef mode using ::NV_ENC_CAPS_SUPPORT_BFRAME_REF_MODE caps.</summary>
         public NvEncBframeRefMode UseBFramesAsRef;
@@ -854,8 +1286,12 @@ namespace Lennox.NvEncSharp
         /// <summary>numRefL1: [in]: Specifies max number of reference frames in reference picture list L1, that can be used by hardware for prediction of a frame.
         /// Check support for numRefL1 using ::NV_ENC_CAPS_SUPPORT_MULTIPLE_REF_FRAMES caps.</summary>
         public NvEncNumRefFrames NumRefL1;
-        /// <summary>reserved1[267]: [in]: Reserved and must be set to 0</summary>
-        private fixed uint Reserved1[267];
+        /// <summary>outputBitDepth: [in]: Specifies pixel bit depth of encoded video. Should be set to NV_ENC_BIT_DEPTH_8 for 8 bit, NV_ENC_BIT_DEPTH_10 for 10 bit.</summary>
+        public NvEncBitDepth OutputBitDepth;
+        /// <summary>inputBitDepth: [in]: Specifies pixel bit depth of video input. Should be set to NV_ENC_BIT_DEPTH_8 for 8 bit input, NV_ENC_BIT_DEPTH_10 for 10 bit input.</summary>
+        public NvEncBitDepth InputBitDepth;
+        /// <summary>reserved1[265]: [in]: Reserved and must be set to 0</summary>
+        private fixed uint Reserved1[265];
         /// <summary>reserved2[64]: [in]: Reserved and must be set to NULL</summary>
         #region Reserved2[64]
         private IntPtr Reserved20;
@@ -976,7 +1412,7 @@ namespace Lennox.NvEncSharp
             get => (BitField1[0] & 32) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 32) : (byte)(BitField1[0] & -33);
         }
-        /// <summary>disableSPSPPS: [in]: Set 1 to disable VPS,SPS and PPS signalling in the bitstream.</summary>
+        /// <summary>disableSPSPPS: [in]: Set 1 to disable VPS, SPS and PPS signaling in the bitstream.</summary>
         public bool DisableSPSPPS {
             get => (BitField1[0] & 64) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 64) : (byte)(BitField1[0] & -65);
@@ -986,7 +1422,7 @@ namespace Lennox.NvEncSharp
             get => (BitField1[0] & 128) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 128) : (byte)(BitField1[0] & -129);
         }
-        internal fixed byte BitField2[3];
+        internal fixed byte BitField2[1];
         /// <summary>enableIntraRefresh: [in]: Set 1 to enable gradual decoder refresh or intra refresh. If the GOP structure uses B frames this will be ignored</summary>
         public bool EnableIntraRefresh {
             get => (BitField2[0] & 1) != 0;
@@ -997,15 +1433,9 @@ namespace Lennox.NvEncSharp
             get { fixed (byte* ptr = &BitField2[0]) { return ((*(uint*)ptr >> 1) & 2); } }
             set => BitField2[0] = (byte)((BitField2[0] & ~4) | (((value) << 1) & 4));
         }
-        /// <summary>pixelBitDepthMinus8: [in]: Specifies pixel bit depth minus 8. Should be set to 0 for 8 bit input, 2 for 10 bit input.</summary>
-        public uint PixelBitDepthMinus8 {
-            get { fixed (byte* ptr = &BitField2[0]) { return ((*(uint*)ptr >> 3) & 3); } }
-            set => BitField2[0] = (byte)((BitField2[0] & ~24) | (((value) << 3) & 24));
-        }
+        /// <summary>reserved3: [in]: Reserved and must be set to 0.</summary>
         /// <summary>enableFillerDataInsertion: [in]: Set to 1 to enable insertion of filler data in the bitstream.
-        /// This flag will take effect only when one of the CBR rate
-        /// control modes (NV_ENC_PARAMS_RC_CBR, NV_ENC_PARAMS_RC_CBR_HQ,
-        /// NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ) is in use and both
+        /// This flag will take effect only when CBR rate control mode is in use and both
         /// NV_ENC_INITIALIZE_PARAMS::frameRateNum and
         /// NV_ENC_INITIALIZE_PARAMS::frameRateDen are set to non-zero
         /// values. Setting this field when
@@ -1016,8 +1446,38 @@ namespace Lennox.NvEncSharp
             get => (BitField2[0] & 64) != 0;
             set => BitField2[0] = value ? (byte)(BitField2[0] | 64) : (byte)(BitField2[0] & -65);
         }
+        /// <summary>enableConstrainedEncoding: [in]: Set this to 1 to enable constrainedFrame encoding where each slice in the constrained picture is independent of other slices.
+        /// Constrained encoding works only with rectangular slices.
+        /// Check support for constrained encoding using ::NV_ENC_CAPS_SUPPORT_CONSTRAINED_ENCODING caps.</summary>
+        public bool EnableConstrainedEncoding {
+            get => (BitField2[0] & 128) != 0;
+            set => BitField2[0] = value ? (byte)(BitField2[0] | 128) : (byte)(BitField2[0] & -129);
+        }
+        internal fixed byte BitField3[2];
+        /// <summary>enableAlphaLayerEncoding: [in]: Set this to 1 to enable HEVC encode with alpha layer.</summary>
+        public bool EnableAlphaLayerEncoding {
+            get => (BitField3[0] & 1) != 0;
+            set => BitField3[0] = value ? (byte)(BitField3[0] | 1) : (byte)(BitField3[0] & -2);
+        }
+        /// <summary>singleSliceIntraRefresh: [in]: Set this to 1 to maintain single slice frames during intra refresh.
+        /// Check support for single slice intra refresh using ::NV_ENC_CAPS_SINGLE_SLICE_INTRA_REFRESH caps.
+        /// This flag will be ignored if the value returned for ::NV_ENC_CAPS_SINGLE_SLICE_INTRA_REFRESH caps is false.</summary>
+        public bool SingleSliceIntraRefresh {
+            get => (BitField3[0] & 2) != 0;
+            set => BitField3[0] = value ? (byte)(BitField3[0] | 2) : (byte)(BitField3[0] & -3);
+        }
+        /// <summary>outputRecoveryPointSEI: [in]: Set to 1 to enable writing of recovery point SEI message</summary>
+        public bool OutputRecoveryPointSEI {
+            get => (BitField3[0] & 4) != 0;
+            set => BitField3[0] = value ? (byte)(BitField3[0] | 4) : (byte)(BitField3[0] & -5);
+        }
+        /// <summary>outputTimeCodeSEI: [in]: Set 1 to write SEI time code syntax in the bitstream. Note that this flag will be ignored for D3D12 interface.</summary>
+        public bool OutputTimeCodeSEI {
+            get => (BitField3[0] & 8) != 0;
+            set => BitField3[0] = value ? (byte)(BitField3[0] | 8) : (byte)(BitField3[0] & -9);
+        }
         /// <summary>reserved: [in]: Reserved bitfields.</summary>
-        /// <summary>idrPeriod: [in]: Specifies the IDR interval. If not set, this is made equal to gopLength in NV_ENC_CONFIG.Low latency application client can set IDR interval to NVENC_INFINITE_GOPLENGTH so that IDR frames are not inserted automatically.</summary>
+        /// <summary>idrPeriod: [in]: Specifies the IDR interval. If not set, this is made equal to gopLength in NV_ENC_CONFIG. Low latency application client can set IDR interval to NVENC_INFINITE_GOPLENGTH so that IDR frames are not inserted automatically.</summary>
         public uint IdrPeriod;
         /// <summary>intraRefreshPeriod: [in]: Specifies the interval between successive intra refresh if enableIntrarefresh is set. Requires enableIntraRefresh to be set.
         /// Will be disabled if NV_ENC_CONFIG::gopLength is not set to NVENC_INFINITE_GOPLENGTH.</summary>
@@ -1028,7 +1488,10 @@ namespace Lennox.NvEncSharp
         public uint MaxNumRefFramesInDPB;
         /// <summary>ltrNumFrames: [in]: This parameter has different meaning in two LTR modes.
         /// In "LTR Trust" mode (ltrTrustMode = 1), encoder will mark the first ltrNumFrames base layer reference frames within each IDR interval as LTR.
-        /// In "LTR Per Picture" mode (ltrTrustMode = 0 and ltrMarkFrame = 1), ltrNumFrames specifies maximum number of LTR frames in DPB.</summary>
+        /// In "LTR Per Picture" mode (ltrTrustMode = 0 and ltrMarkFrame = 1), ltrNumFrames specifies maximum number of LTR frames in DPB.
+        /// These ltrNumFrames acts as a guidance to the encoder and are not necessarily honored. To achieve a right balance between the encoding
+        /// quality and keeping LTR frames in the DPB queue, the encoder can internally limit the number of LTR frames.
+        /// The number of LTR frames actually used depends upon the encoding preset being used; Faster encoding presets will use fewer LTR frames.</summary>
         public uint LtrNumFrames;
         /// <summary>vpsId: [in]: Specifies the VPS id of the video parameter set</summary>
         public uint VpsId;
@@ -1048,7 +1511,7 @@ namespace Lennox.NvEncSharp
         public uint SliceModeData;
         /// <summary>maxTemporalLayersMinus1: [in]: Specifies the max temporal layer used for hierarchical coding.</summary>
         public uint MaxTemporalLayersMinus1;
-        /// <summary>hevcVUIParameters: [in]: Specifies the HEVC video usability info pamameters</summary>
+        /// <summary>hevcVUIParameters: [in]: Specifies the HEVC video usability info parameters</summary>
         public NvEncConfigH264VuiParameters HevcVUIParameters;
         /// <summary>ltrTrustMode: [in]: Specifies the LTR operating mode. See comments near NV_ENC_CONFIG_HEVC::enableLTR for description of the two modes.
         /// Set to 1 to use "LTR Trust" mode of LTR operation. Clients are discouraged to use "LTR Trust" mode as this mode may
@@ -1063,8 +1526,25 @@ namespace Lennox.NvEncSharp
         /// <summary>numRefL1: [in]: Specifies max number of reference frames in reference picture list L1, that can be used by hardware for prediction of a frame.
         /// Check support for numRefL1 using ::NV_ENC_CAPS_SUPPORT_MULTIPLE_REF_FRAMES caps.</summary>
         public NvEncNumRefFrames NumRefL1;
-        /// <summary>reserved1[214]: [in]: Reserved and must be set to 0.</summary>
-        private fixed uint Reserved1[214];
+        /// <summary>tfLevel: [in]: Specifies the strength of the temporal filtering.
+        /// Temporal filter feature is supported only if frameIntervalP >= 5.
+        /// Temporal filter feature is not supported with ZeroReorderDelay/enableStereoMVC/AlphaLayerEncoding.
+        /// Temporal filter is recommended for natural contents.</summary>
+        public NvEncTemporalFilterLevel TfLevel;
+        /// <summary>disableDeblockingFilterIDC: [in]: Specifies the deblocking filter mode. Permissible value range: [0,2]. This flag corresponds
+        /// to the flag pps_deblocking_filter_disabled_flag specified in section 7.4.3.3 of H.265 specification,
+        /// which specifies whether the operation of the deblocking filter shall be disabled across some
+        /// block edges of the slice and specifies for which edges the filtering is disabled. See section
+        /// 7.4.3.3 of H.265 specification for more details.</summary>
+        public uint DisableDeblockingFilterIDC;
+        /// <summary>outputBitDepth: [in]: Specifies pixel bit depth of encoded video. Should be set to NV_ENC_BIT_DEPTH_8 for 8 bit, NV_ENC_BIT_DEPTH_10 for 10 bit.
+        /// SW will do the bitdepth conversion internally from inputBitDepth -> outputBitDepth if bit depths differ
+        /// Support for 8 bit input to 10 bit encode conversion only</summary>
+        public NvEncBitDepth OutputBitDepth;
+        /// <summary>inputBitDepth: [in]: Specifies pixel bit depth of video input. Should be set to NV_ENC_BIT_DEPTH_8 for 8 bit input, NV_ENC_BIT_DEPTH_10 for 10 bit input.</summary>
+        public NvEncBitDepth InputBitDepth;
+        /// <summary>reserved1[210]: [in]: Reserved and must be set to 0.</summary>
+        private fixed uint Reserved1[210];
         /// <summary>reserved2[64]: [in]: Reserved and must be set to NULL</summary>
         #region Reserved2[64]
         private IntPtr Reserved20;
@@ -1134,6 +1614,302 @@ namespace Lennox.NvEncSharp
         #endregion Reserved2[64]
     }
 
+    /// <summary>NV_ENC_FILM_GRAIN_PARAMS_AV1
+    /// struct _NV_ENC_FILM_GRAIN_PARAMS_AV1
+    /// AV1 Film Grain Parameters structure</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct NvEncFilmGrainParamsAv1
+    {
+        internal fixed byte BitField1[1];
+        /// <summary>applyGrain: [in]: Set to 1 to specify film grain should be added to frame</summary>
+        public bool ApplyGrain {
+            get => (BitField1[0] & 1) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 1) : (byte)(BitField1[0] & -2);
+        }
+        /// <summary>chromaScalingFromLuma: [in]: Set to 1 to specify the chroma scaling is inferred from luma scaling</summary>
+        public bool ChromaScalingFromLuma {
+            get => (BitField1[0] & 2) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 2) : (byte)(BitField1[0] & -3);
+        }
+        /// <summary>overlapFlag: [in]: Set to 1 to indicate that overlap between film grain blocks should be applied</summary>
+        public bool OverlapFlag {
+            get => (BitField1[0] & 4) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 4) : (byte)(BitField1[0] & -5);
+        }
+        /// <summary>clipToRestrictedRange: [in]: Set to 1 to clip values to restricted (studio) range after adding film grain</summary>
+        public bool ClipToRestrictedRange {
+            get => (BitField1[0] & 8) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 8) : (byte)(BitField1[0] & -9);
+        }
+        /// <summary>grainScalingMinus8: [in]: Represents the shift - 8 applied to the values of the chroma component</summary>
+        public uint GrainScalingMinus8 {
+            get { fixed (byte* ptr = &BitField1[0]) { return ((*(uint*)ptr >> 4) & 2); } }
+            set => BitField1[0] = (byte)((BitField1[0] & ~32) | (((value) << 4) & 32));
+        }
+        /// <summary>arCoeffLag: [in]: Specifies the number of auto-regressive coefficients for luma and chroma</summary>
+        public uint ArCoeffLag {
+            get { fixed (byte* ptr = &BitField1[0]) { return ((*(uint*)ptr >> 6) & 2); } }
+            set => BitField1[0] = (byte)((BitField1[0] & ~128) | (((value) << 6) & 128));
+        }
+        internal fixed byte BitField2[1];
+        /// <summary>numYPoints: [in]: Specifies the number of points for the piecewise linear scaling function of the luma component</summary>
+        public uint NumYPoints {
+            get { fixed (byte* ptr = &BitField2[0]) { return ((*(uint*)ptr >> 0) & 4); } }
+            set => BitField2[0] = (byte)((BitField2[0] & ~4) | (((value) << 0) & 4));
+        }
+        /// <summary>numCbPoints: [in]: Specifies the number of points for the piecewise linear scaling function of the cb component</summary>
+        public uint NumCbPoints {
+            get { fixed (byte* ptr = &BitField2[0]) { return ((*(uint*)ptr >> 4) & 4); } }
+            set => BitField2[0] = (byte)((BitField2[0] & ~64) | (((value) << 4) & 64));
+        }
+        internal fixed byte BitField3[1];
+        /// <summary>numCrPoints: [in]: Specifies the number of points for the piecewise linear scaling function of the cr component</summary>
+        public uint NumCrPoints {
+            get { fixed (byte* ptr = &BitField3[0]) { return ((*(uint*)ptr >> 0) & 4); } }
+            set => BitField3[0] = (byte)((BitField3[0] & ~4) | (((value) << 0) & 4));
+        }
+        /// <summary>arCoeffShiftMinus6: [in]: specifies the range of the auto-regressive coefficients</summary>
+        public uint ArCoeffShiftMinus6 {
+            get { fixed (byte* ptr = &BitField3[0]) { return ((*(uint*)ptr >> 4) & 2); } }
+            set => BitField3[0] = (byte)((BitField3[0] & ~32) | (((value) << 4) & 32));
+        }
+        /// <summary>grainScaleShift: [in]: Specifies how much the Gaussian random numbers should be scaled down during the grain synthesi process</summary>
+        public uint GrainScaleShift {
+            get { fixed (byte* ptr = &BitField3[0]) { return ((*(uint*)ptr >> 6) & 2); } }
+            set => BitField3[0] = (byte)((BitField3[0] & ~128) | (((value) << 6) & 128));
+        }
+        internal fixed byte BitField4[1];
+        /// <summary>reserved1: [in]: Reserved bits field - should be set to 0</summary>
+        /// <summary>pointYValue[14]: [in]: pointYValue[i]: x coordinate for i-th point of luma piecewise linear scaling function. Values on a scale of 0...255</summary>
+        public fixed byte PointYValue[14];
+        /// <summary>pointYScaling[14]: [in]: pointYScaling[i]: i-th point output value of luma piecewise linear scaling function</summary>
+        public fixed byte PointYScaling[14];
+        /// <summary>pointCbValue[10]: [in]: pointCbValue[i]: x coordinate for i-th point of cb piecewise linear scaling function. Values on a scale of 0...255</summary>
+        public fixed byte PointCbValue[10];
+        /// <summary>pointCbScaling[10]: [in]: pointCbScaling[i]: i-th point output value of cb piecewise linear scaling function</summary>
+        public fixed byte PointCbScaling[10];
+        /// <summary>pointCrValue[10]: [in]: pointCrValue[i]: x coordinate for i-th point of cr piecewise linear scaling function. Values on a scale of 0...255</summary>
+        public fixed byte PointCrValue[10];
+        /// <summary>pointCrScaling[10]: [in]: pointCrScaling[i]: i-th point output value of cr piecewise linear scaling function</summary>
+        public fixed byte PointCrScaling[10];
+        /// <summary>arCoeffsYPlus128[24]: [in]: Specifies auto-regressive coefficients used for the Y plane</summary>
+        public fixed byte ArCoeffsYPlus128[24];
+        /// <summary>arCoeffsCbPlus128[25]: [in]: Specifies auto-regressive coefficients used for the U plane</summary>
+        public fixed byte ArCoeffsCbPlus128[25];
+        /// <summary>arCoeffsCrPlus128[25]: [in]: Specifies auto-regressive coefficients used for the V plane</summary>
+        public fixed byte ArCoeffsCrPlus128[25];
+        /// <summary>reserved2[2]: [in]: Reserved bytes - should be set to 0</summary>
+        private fixed byte Reserved2[2];
+        /// <summary>cbMult: [in]: Represents a multiplier for the cb component used in derivation of the input index to the cb component scaling function</summary>
+        public byte CbMult;
+        /// <summary>cbLumaMult: [in]: represents a multiplier for the average luma component used in derivation of the input index to the cb component scaling function.</summary>
+        public byte CbLumaMult;
+        /// <summary>cbOffset: [in]: Represents an offset used in derivation of the input index to the cb component scaling function</summary>
+        public ushort CbOffset;
+        /// <summary>crMult: [in]: Represents a multiplier for the cr component used in derivation of the input index to the cr component scaling function</summary>
+        public byte CrMult;
+        /// <summary>crLumaMult: [in]: represents a multiplier for the average luma component used in derivation of the input index to the cr component scaling function.</summary>
+        public byte CrLumaMult;
+        /// <summary>crOffset: [in]: Represents an offset used in derivation of the input index to the cr component scaling function</summary>
+        public ushort CrOffset;
+    }
+
+    /// <summary>NV_ENC_CONFIG_AV1
+    /// struct _NV_ENC_CONFIG_AV1
+    /// AV1 encoder configuration parameters to be set during initialization.</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct NvEncConfigAv1
+    {
+        /// <summary>level: [in]: Specifies the level of the encoded bitstream.</summary>
+        public uint Level;
+        /// <summary>tier: [in]: Specifies the level tier of the encoded bitstream.</summary>
+        public uint Tier;
+        /// <summary>minPartSize: [in]: Specifies the minimum size of luma coding block partition.</summary>
+        public NvEncAv1PartSize MinPartSize;
+        /// <summary>maxPartSize: [in]: Specifies the maximum size of luma coding block partition.</summary>
+        public NvEncAv1PartSize MaxPartSize;
+        internal fixed byte BitField1[4];
+        /// <summary>outputAnnexBFormat: [in]: Set 1 to use Annex B format for bitstream output.</summary>
+        public bool OutputAnnexBFormat {
+            get => (BitField1[0] & 1) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 1) : (byte)(BitField1[0] & -2);
+        }
+        /// <summary>enableTimingInfo: [in]: Set 1 to write Timing Info into sequence/frame headers</summary>
+        public bool EnableTimingInfo {
+            get => (BitField1[0] & 2) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 2) : (byte)(BitField1[0] & -3);
+        }
+        /// <summary>enableDecoderModelInfo: [in]: Set 1 to write Decoder Model Info into sequence/frame headers</summary>
+        public bool EnableDecoderModelInfo {
+            get => (BitField1[0] & 4) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 4) : (byte)(BitField1[0] & -5);
+        }
+        /// <summary>enableFrameIdNumbers: [in]: Set 1 to write Frame id numbers in bitstream</summary>
+        public bool EnableFrameIdNumbers {
+            get => (BitField1[0] & 8) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 8) : (byte)(BitField1[0] & -9);
+        }
+        /// <summary>disableSeqHdr: [in]: Set 1 to disable Sequence Header signaling in the bitstream.</summary>
+        public bool DisableSeqHdr {
+            get => (BitField1[0] & 16) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 16) : (byte)(BitField1[0] & -17);
+        }
+        /// <summary>repeatSeqHdr: [in]: Set 1 to output Sequence Header for every Key frame.</summary>
+        public bool RepeatSeqHdr {
+            get => (BitField1[0] & 32) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 32) : (byte)(BitField1[0] & -33);
+        }
+        /// <summary>enableIntraRefresh: [in]: Set 1 to enable gradual decoder refresh or intra refresh. If the GOP structure uses B frames this will be ignored</summary>
+        public bool EnableIntraRefresh {
+            get => (BitField1[0] & 64) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 64) : (byte)(BitField1[0] & -65);
+        }
+        /// <summary>chromaFormatIDC: [in]: Specifies the chroma format. Should be set to 1 for yuv420 input (yuv444 input currently not supported).</summary>
+        public uint ChromaFormatIDC {
+            get { fixed (byte* ptr = &BitField1[0]) { return ((*(uint*)ptr >> 7) & 2); } }
+            set => BitField1[0] = (byte)((BitField1[0] & ~256) | (((value) << 7) & 256));
+        }
+        /// <summary>enableBitstreamPadding: [in]: Set 1 to enable bitstream padding.</summary>
+        public bool EnableBitstreamPadding {
+            get => (BitField1[1] & 512) != 0;
+            set => BitField1[1] = value ? (byte)(BitField1[1] | 512) : (byte)(BitField1[1] & -513);
+        }
+        /// <summary>enableCustomTileConfig: [in]: Set 1 to enable custom tile configuration: numTileColumns and numTileRows must have non zero values and tileWidths and tileHeights must point to a valid address</summary>
+        public bool EnableCustomTileConfig {
+            get => (BitField1[1] & 1024) != 0;
+            set => BitField1[1] = value ? (byte)(BitField1[1] | 1024) : (byte)(BitField1[1] & -1025);
+        }
+        /// <summary>enableFilmGrainParams: [in]: Set 1 to enable custom film grain parameters: filmGrainParams must point to a valid address</summary>
+        public bool EnableFilmGrainParams {
+            get => (BitField1[1] & 2048) != 0;
+            set => BitField1[1] = value ? (byte)(BitField1[1] | 2048) : (byte)(BitField1[1] & -2049);
+        }
+        /// <summary>reserved4: [in]: Reserved and must be set to 0.</summary>
+        /// <summary>reserved: [in]: Reserved bitfields.</summary>
+        /// <summary>idrPeriod: [in]: Specifies the IDR/Key frame interval. If not set, this is made equal to gopLength in NV_ENC_CONFIG.Low latency application client can set IDR interval to NVENC_INFINITE_GOPLENGTH so that IDR frames are not inserted automatically.</summary>
+        public uint IdrPeriod;
+        /// <summary>intraRefreshPeriod: [in]: Specifies the interval between successive intra refresh if enableIntrarefresh is set. Requires enableIntraRefresh to be set.
+        /// Will be disabled if NV_ENC_CONFIG::gopLength is not set to NVENC_INFINITE_GOPLENGTH.</summary>
+        public uint IntraRefreshPeriod;
+        /// <summary>intraRefreshCnt: [in]: Specifies the length of intra refresh in number of frames for periodic intra refresh. This value should be smaller than intraRefreshPeriod</summary>
+        public uint IntraRefreshCnt;
+        /// <summary>maxNumRefFramesInDPB: [in]: Specifies the maximum number of references frames in the DPB.</summary>
+        public uint MaxNumRefFramesInDPB;
+        /// <summary>numTileColumns: [in]: This parameter in conjunction with the flag enableCustomTileConfig and the array tileWidths[] specifies the way in which the picture is divided into tile columns.
+        /// When enableCustomTileConfig == 0, the picture will be uniformly divided into numTileColumns tile columns. If numTileColumns is not a power of 2,
+        /// it will be rounded down to the next power of 2 value. If numTileColumns == 0, the picture will be coded with the smallest number of vertical tiles as allowed by standard.
+        /// When enableCustomTileConfig == 1, numTileColumns must be > 0 and <= NV_MAX_TILE_COLS_AV1 and tileWidths must point to a valid array of numTileColumns entries.
+        /// Entry i specifies the width in 64x64 CTU unit of tile colum i. The sum of all the entries should be equal to the picture width in 64x64 CTU units.</summary>
+        public uint NumTileColumns;
+        /// <summary>numTileRows: [in]: This parameter in conjunction with the flag enableCustomTileConfig and the array tileHeights[] specifies the way in which the picture is divided into tiles rows
+        /// When enableCustomTileConfig == 0, the picture will be uniformly divided into numTileRows tile rows. If numTileRows is not a power of 2,
+        /// it will be rounded down to the next power of 2 value. If numTileRows == 0, the picture will be coded with the smallest number of horizontal tiles as allowed by standard.
+        /// When enableCustomTileConfig == 1, numTileRows must be > 0 and <= NV_MAX_TILE_ROWS_AV1 and tileHeights must point to a valid array of numTileRows entries.
+        /// Entry i specifies the height in 64x64 CTU unit of tile row i. The sum of all the entries should be equal to the picture hieght in 64x64 CTU units.</summary>
+        public uint NumTileRows;
+        /// <summary>reserved2: [in]: Reserved and must be set to 0.</summary>
+        private uint Reserved2;
+        /// <summary>*tileWidths: [in]: If enableCustomTileConfig == 1, tileWidths[i] specifies the width of tile column i in 64x64 CTU unit, with 0 <= i <= numTileColumns -1.</summary>
+        public uint *tileWidths;
+        /// <summary>*tileHeights: [in]: If enableCustomTileConfig == 1, tileHeights[i] specifies the height of tile row i in 64x64 CTU unit, with 0 <= i <= numTileRows -1.</summary>
+        public uint *tileHeights;
+        /// <summary>maxTemporalLayersMinus1: [in]: Specifies the max temporal layer used for hierarchical coding. Cannot be reconfigured and must be specified during encoder creation if temporal layer is considered.</summary>
+        public uint MaxTemporalLayersMinus1;
+        /// <summary>colorPrimaries: [in]: as defined in section of ISO/IEC 23091-4/ITU-T H.273</summary>
+        public NvEncVuiColorPrimaries ColorPrimaries;
+        /// <summary>transferCharacteristics: [in]: as defined in section of ISO/IEC 23091-4/ITU-T H.273</summary>
+        public NvEncVuiTransferCharacteristic TransferCharacteristics;
+        /// <summary>matrixCoefficients: [in]: as defined in section of ISO/IEC 23091-4/ITU-T H.273</summary>
+        public NvEncVuiMatrixCoeffs MatrixCoefficients;
+        /// <summary>colorRange: [in]: 0: studio swing representation - 1: full swing representation</summary>
+        public uint ColorRange;
+        /// <summary>chromaSamplePosition: [in]: 0: unknown
+        /// 1: Horizontally collocated with luma (0,0) sample, between two vertical samples
+        /// 2: Co-located with luma (0,0) sample</summary>
+        public uint ChromaSamplePosition;
+        /// <summary>useBFramesAsRef: [in]: Specifies the B-Frame as reference mode. Check support for useBFramesAsRef mode using ::NV_ENC_CAPS_SUPPORT_BFRAME_REF_MODE caps.</summary>
+        public NvEncBframeRefMode UseBFramesAsRef;
+        /// <summary>*filmGrainParams: [in]: If enableFilmGrainParams == 1, filmGrainParams must point to a valid NV_ENC_FILM_GRAIN_PARAMS_AV1 structure</summary>
+        public NvEncFilmGrainParamsAv1 *filmGrainParams;
+        /// <summary>numFwdRefs: [in]: Specifies max number of forward reference frame used for prediction of a frame. It must be in range 1-4 (Last, Last2, last3 and Golden). It's a suggestive value not necessarily be honored always.</summary>
+        public NvEncNumRefFrames NumFwdRefs;
+        /// <summary>numBwdRefs: [in]: Specifies max number of L1 list reference frame used for prediction of a frame. It must be in range 1-3 (Backward, Altref2, Altref). It's a suggestive value not necessarily be honored always.</summary>
+        public NvEncNumRefFrames NumBwdRefs;
+        /// <summary>outputBitDepth: [in]: Specifies pixel bit depth of encoded video. Should be set to NV_ENC_BIT_DEPTH_8 for 8 bit, NV_ENC_BIT_DEPTH_10 for 10 bit.
+        /// HW will do the bitdepth conversion internally from inputBitDepth -> outputBitDepth if bit depths differ
+        /// Support for 8 bit input to 10 bit encode conversion only</summary>
+        public NvEncBitDepth OutputBitDepth;
+        /// <summary>inputBitDepth: [in]: Specifies pixel bit depth of video input. Should be set to NV_ENC_BIT_DEPTH_8 for 8 bit input, NV_ENC_BIT_DEPTH_10 for 10 bit input.</summary>
+        public NvEncBitDepth InputBitDepth;
+        /// <summary>reserved1[233]: [in]: Reserved and must be set to 0.</summary>
+        private fixed uint Reserved1[233];
+        /// <summary>reserved3[62]: [in]: Reserved and must be set to NULL</summary>
+        #region Reserved3[62]
+        private IntPtr Reserved30;
+        private IntPtr Reserved31;
+        private IntPtr Reserved32;
+        private IntPtr Reserved33;
+        private IntPtr Reserved34;
+        private IntPtr Reserved35;
+        private IntPtr Reserved36;
+        private IntPtr Reserved37;
+        private IntPtr Reserved38;
+        private IntPtr Reserved39;
+        private IntPtr Reserved310;
+        private IntPtr Reserved311;
+        private IntPtr Reserved312;
+        private IntPtr Reserved313;
+        private IntPtr Reserved314;
+        private IntPtr Reserved315;
+        private IntPtr Reserved316;
+        private IntPtr Reserved317;
+        private IntPtr Reserved318;
+        private IntPtr Reserved319;
+        private IntPtr Reserved320;
+        private IntPtr Reserved321;
+        private IntPtr Reserved322;
+        private IntPtr Reserved323;
+        private IntPtr Reserved324;
+        private IntPtr Reserved325;
+        private IntPtr Reserved326;
+        private IntPtr Reserved327;
+        private IntPtr Reserved328;
+        private IntPtr Reserved329;
+        private IntPtr Reserved330;
+        private IntPtr Reserved331;
+        private IntPtr Reserved332;
+        private IntPtr Reserved333;
+        private IntPtr Reserved334;
+        private IntPtr Reserved335;
+        private IntPtr Reserved336;
+        private IntPtr Reserved337;
+        private IntPtr Reserved338;
+        private IntPtr Reserved339;
+        private IntPtr Reserved340;
+        private IntPtr Reserved341;
+        private IntPtr Reserved342;
+        private IntPtr Reserved343;
+        private IntPtr Reserved344;
+        private IntPtr Reserved345;
+        private IntPtr Reserved346;
+        private IntPtr Reserved347;
+        private IntPtr Reserved348;
+        private IntPtr Reserved349;
+        private IntPtr Reserved350;
+        private IntPtr Reserved351;
+        private IntPtr Reserved352;
+        private IntPtr Reserved353;
+        private IntPtr Reserved354;
+        private IntPtr Reserved355;
+        private IntPtr Reserved356;
+        private IntPtr Reserved357;
+        private IntPtr Reserved358;
+        private IntPtr Reserved359;
+        private IntPtr Reserved360;
+        private IntPtr Reserved361;
+        #endregion Reserved3[62]
+    }
+
     /// <summary>NV_ENC_CONFIG_H264_MEONLY
     /// struct _NV_ENC_CONFIG_H264_MEONLY
     /// H264 encoder configuration parameters for ME only Mode</summary>
@@ -1141,27 +1917,27 @@ namespace Lennox.NvEncSharp
     public unsafe struct NvEncConfigH264Meonly
     {
         internal fixed byte BitField1[4];
-        /// <summary>disablePartition16x16: [in]: Disable MotionEstimation on 16x16 blocks</summary>
+        /// <summary>disablePartition16x16: [in]: Disable Motion Estimation on 16x16 blocks</summary>
         public bool DisablePartition16x16 {
             get => (BitField1[0] & 1) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 1) : (byte)(BitField1[0] & -2);
         }
-        /// <summary>disablePartition8x16: [in]: Disable MotionEstimation on 8x16 blocks</summary>
+        /// <summary>disablePartition8x16: [in]: Disable Motion Estimation on 8x16 blocks</summary>
         public bool DisablePartition8x16 {
             get => (BitField1[0] & 2) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 2) : (byte)(BitField1[0] & -3);
         }
-        /// <summary>disablePartition16x8: [in]: Disable MotionEstimation on 16x8 blocks</summary>
+        /// <summary>disablePartition16x8: [in]: Disable Motion Estimation on 16x8 blocks</summary>
         public bool DisablePartition16x8 {
             get => (BitField1[0] & 4) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 4) : (byte)(BitField1[0] & -5);
         }
-        /// <summary>disablePartition8x8: [in]: Disable MotionEstimation on 8x8 blocks</summary>
+        /// <summary>disablePartition8x8: [in]: Disable Motion Estimation on 8x8 blocks</summary>
         public bool DisablePartition8x8 {
             get => (BitField1[0] & 8) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 8) : (byte)(BitField1[0] & -9);
         }
-        /// <summary>disableIntraSearch: [in]: Disable Intra search during MotionEstimation</summary>
+        /// <summary>disableIntraSearch: [in]: Disable Intra search during Motion Estimation</summary>
         public bool DisableIntraSearch {
             get => (BitField1[0] & 16) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 16) : (byte)(BitField1[0] & -17);
@@ -1328,7 +2104,7 @@ namespace Lennox.NvEncSharp
     {
         /// <summary>version: [in]: Struct version. Must be set to ::NV_ENC_CONFIG_VER.</summary>
         public uint Version;
-        /// <summary>profileGUID: [in]: Specifies the codec profile guid. If client specifies \p NV_ENC_CODEC_PROFILE_AUTOSELECT_GUID the NvEncodeAPI interface will select the appropriate codec profile.</summary>
+        /// <summary>profileGUID: [in]: Specifies the codec profile GUID. If client specifies \p NV_ENC_CODEC_PROFILE_AUTOSELECT_GUID the NvEncodeAPI interface will select the appropriate codec profile.</summary>
         public Guid ProfileGuid;
         /// <summary>gopLength: [in]: Specifies the number of pictures in one GOP. Low latency application client can set goplength to NVENC_INFINITE_GOPLENGTH so that keyframes are not inserted automatically.</summary>
         public uint GopLength;
@@ -1433,9 +2209,9 @@ namespace Lennox.NvEncSharp
         public uint EncodeWidth;
         /// <summary>encodeHeight: [in]: Specifies the encode height. If not set ::NvEncInitializeEncoder() API will fail.</summary>
         public uint EncodeHeight;
-        /// <summary>darWidth: [in]: Specifies the display aspect ratio Width.</summary>
+        /// <summary>darWidth: [in]: Specifies the display aspect ratio width (H264/HEVC) or the render width (AV1).</summary>
         public uint DarWidth;
-        /// <summary>darHeight: [in]: Specifies the display aspect ratio height.</summary>
+        /// <summary>darHeight: [in]: Specifies the display aspect ratio height (H264/HEVC) or the render height (AV1).</summary>
         public uint DarHeight;
         /// <summary>frameRateNum: [in]: Specifies the numerator for frame rate used for encoding in frames per second ( Frame rate = frameRateNum / frameRateDen ).</summary>
         public uint FrameRateNum;
@@ -1451,7 +2227,10 @@ namespace Lennox.NvEncSharp
             get => (BitField1[0] & 1) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 1) : (byte)(BitField1[0] & -2);
         }
-        /// <summary>enableSubFrameWrite: [in]: Set this to 1 to write out available bitstream to memory at subframe intervals</summary>
+        /// <summary>enableSubFrameWrite: [in]: Set this to 1 to write out available bitstream to memory at subframe intervals.
+        /// If enableSubFrameWrite = 1, then the hardware encoder returns data as soon as a slice (H264/HEVC) or tile (AV1) has completed encoding.
+        /// This results in better encoding latency, but the downside is that the application has to keep polling via a call to nvEncLockBitstream API continuously to see if any encoded slice/tile data is available.
+        /// Use this mode if you feel that the marginal reduction in latency from sub-frame encoding is worth the increase in complexity due to CPU-based polling.</summary>
         public bool EnableSubFrameWrite {
             get => (BitField1[0] & 2) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 2) : (byte)(BitField1[0] & -3);
@@ -1467,24 +2246,53 @@ namespace Lennox.NvEncSharp
             get => (BitField1[0] & 8) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 8) : (byte)(BitField1[0] & -9);
         }
-        /// <summary>enableWeightedPrediction: [in]: Set this to 1 to enable weighted prediction. Not supported if encode session is configured for B-Frames( 'frameIntervalP' in NV_ENC_CONFIG is greater than 1).</summary>
+        /// <summary>enableWeightedPrediction: [in]: Set this to 1 to enable weighted prediction. Not supported if encode session is configured for B-Frames (i.e. NV_ENC_CONFIG::frameIntervalP > 1 or preset >=P3 when tuningInfo = ::NV_ENC_TUNING_INFO_HIGH_QUALITY or
+        /// tuningInfo = ::NV_ENC_TUNING_INFO_LOSSLESS. This is because preset >=p3 internally enables B frames when tuningInfo = ::NV_ENC_TUNING_INFO_HIGH_QUALITY or ::NV_ENC_TUNING_INFO_LOSSLESS).</summary>
         public bool EnableWeightedPrediction {
             get => (BitField1[0] & 16) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 16) : (byte)(BitField1[0] & -17);
         }
+        /// <summary>splitEncodeMode: [in]: Split Encoding mode in NVENC (Split Encoding is not applicable to H264).
+        /// Not supported if any of the following features: weighted prediction, alpha layer encoding,
+        /// subframe mode, output into video memory buffer, picture timing/buffering period SEI message
+        /// insertion with DX12 interface are enabled in case of HEVC.
+        /// For AV1, split encoding is not supported when output into video memory buffer is enabled.</summary>
+        public uint SplitEncodeMode {
+            get { fixed (byte* ptr = &BitField1[0]) { return ((*(uint*)ptr >> 5) & 4); } }
+            set => BitField1[0] = (byte)((BitField1[0] & ~128) | (((value) << 5) & 128));
+        }
         /// <summary>enableOutputInVidmem: [in]: Set this to 1 to enable output of NVENC in video memory buffer created by application. This feature is not supported for HEVC ME only mode.</summary>
         public bool EnableOutputInVidmem {
-            get => (BitField1[0] & 32) != 0;
-            set => BitField1[0] = value ? (byte)(BitField1[0] | 32) : (byte)(BitField1[0] & -33);
+            get => (BitField1[1] & 512) != 0;
+            set => BitField1[1] = value ? (byte)(BitField1[1] | 512) : (byte)(BitField1[1] & -513);
+        }
+        /// <summary>enableReconFrameOutput: [in]: Set this to 1 to enable reconstructed frame output.</summary>
+        public bool EnableReconFrameOutput {
+            get => (BitField1[1] & 1024) != 0;
+            set => BitField1[1] = value ? (byte)(BitField1[1] | 1024) : (byte)(BitField1[1] & -1025);
+        }
+        /// <summary>enableOutputStats: [in]: Set this to 1 to enable encoded frame output stats. Client must allocate buffer of size equal to number of blocks multiplied by the size of
+        /// NV_ENC_OUTPUT_STATS_BLOCK struct in system memory and assign to NV_ENC_LOCK_BITSTREAM::encodedOutputStatsPtr to receive the encoded frame output stats.</summary>
+        public bool EnableOutputStats {
+            get => (BitField1[1] & 2048) != 0;
+            set => BitField1[1] = value ? (byte)(BitField1[1] | 2048) : (byte)(BitField1[1] & -2049);
+        }
+        /// <summary>enableUniDirectionalB: [in]: Set this to 1 to enable uni directional B-frame(both reference will be from past). It will give better compression
+        /// efficiency for LowLatency/UltraLowLatency use case. Value of parameter is ignored when regular B frames are used.</summary>
+        public bool EnableUniDirectionalB {
+            get => (BitField1[1] & 4096) != 0;
+            set => BitField1[1] = value ? (byte)(BitField1[1] | 4096) : (byte)(BitField1[1] & -4097);
         }
         /// <summary>reservedBitFields: [in]: Reserved bitfields and must be set to 0</summary>
         /// <summary>privDataSize: [in]: Reserved private data buffer size and must be set to 0</summary>
         public uint PrivDataSize;
+        /// <summary>reserved: [in]: Reserved and must be set to 0</summary>
+        private uint Reserved;
         /// <summary>privData: [in]: Reserved private data buffer and must be set to NULL</summary>
         public IntPtr PrivData;
         /// <summary>encodeConfig: [in]: Specifies the advanced codec specific structure. If client has sent a valid codec config structure, it will override parameters set by the NV_ENC_INITIALIZE_PARAMS::presetGUID parameter. If set to NULL the NvEncodeAPI interface will use the NV_ENC_INITIALIZE_PARAMS::presetGUID to set the codec specific parameters.
-        /// Client can also optionally query the NvEncodeAPI interface to get codec specific parameters for a presetGUID using ::NvEncGetEncodePresetConfig() API. It can then modify (if required) some of the codec config parameters and send down a custom config structure as part of ::_NV_ENC_INITIALIZE_PARAMS.
-        /// Even in this case client is recommended to pass the same preset guid it has used in ::NvEncGetEncodePresetConfig() API to query the config structure; as NV_ENC_INITIALIZE_PARAMS::presetGUID. This will not override the custom config structure but will be used to determine other Encoder HW specific parameters not exposed in the API.</summary>
+        /// Client can also optionally query the NvEncodeAPI interface to get codec specific parameters for a presetGUID using ::NvEncGetEncodePresetConfigEx() API. It can then modify (if required) some of the codec config parameters and send down a custom config structure as part of ::_NV_ENC_INITIALIZE_PARAMS.
+        /// Even in this case client is recommended to pass the same preset guid it has used in ::NvEncGetEncodePresetConfigEx() API to query the config structure; as NV_ENC_INITIALIZE_PARAMS::presetGUID. This will not override the custom config structure but will be used to determine other Encoder HW specific parameters not exposed in the API.</summary>
         public NvEncConfig* EncodeConfig;
         /// <summary>maxEncodeWidth: [in]: Maximum encode width to be used for current Encode session.
         /// Client should allocate output buffers according to this dimension for dynamic resolution change. If set to 0, Encoder will not allow dynamic resolution change.</summary>
@@ -1497,8 +2305,20 @@ namespace Lennox.NvEncSharp
         /// This client must also set NV_ENC_INITIALIZE_PARAMS::enableExternalMEHints to 1.</summary>
         public NvEncExternalMeHintCountsPerBlocktype MaxMEHintCountsPerBlock0;
         public NvEncExternalMeHintCountsPerBlocktype MaxMEHintCountsPerBlock1;
-        /// <summary>reserved [289]: [in]: Reserved and must be set to 0</summary>
-        private fixed uint Reserved [289];
+        /// <summary>tuningInfo: [in]: Tuning Info of NVENC encoding(TuningInfo is not applicable to H264 and HEVC meonly mode).</summary>
+        public NvEncTuningInfo TuningInfo;
+        /// <summary>bufferFormat: [in]: Input buffer format. Used only when DX12 interface type is used</summary>
+        public NvEncBufferFormat BufferFormat;
+        /// <summary>numStateBuffers: [in]: Number of state buffers to allocate to save encoder state. Set this to value greater than zero to enable encoding without advancing the encoder state.</summary>
+        public uint NumStateBuffers;
+        /// <summary>outputStatsLevel: [in]: Specifies the level for encoded frame output stats, when NV_ENC_INITIALIZE_PARAMS::enableOutputStats is set to 1.
+        /// Client should allocate buffer of size equal to number of blocks multiplied by the size of NV_ENC_OUTPUT_STATS_BLOCK struct
+        /// if NV_ENC_INITIALIZE_PARAMS::outputStatsLevel is set to NV_ENC_OUTPUT_STATS_BLOCK or number of rows multiplied by the size of
+        /// NV_ENC_OUTPUT_STATS_ROW struct if NV_ENC_INITIALIZE_PARAMS::outputStatsLevel is set to NV_ENC_OUTPUT_STATS_ROW
+        /// in system memory and assign to NV_ENC_LOCK_BITSTREAM::encodedOutputStatsPtr to receive the encoded frame output stats.</summary>
+        public NvEncOutputStatsLevel OutputStatsLevel;
+        /// <summary>reserved1 [284]: [in]: Reserved and must be set to 0</summary>
+        private fixed uint Reserved1 [284];
         /// <summary>reserved2[64]: [in]: Reserved and must be set to NULL</summary>
         #region Reserved2[64]
         private IntPtr Reserved20;
@@ -1576,6 +2396,8 @@ namespace Lennox.NvEncSharp
     {
         /// <summary>version: [in]: Struct version. Must be set to ::NV_ENC_RECONFIGURE_PARAMS_VER.</summary>
         public uint Version;
+        /// <summary>reserved: [in]: Reserved and must be set to 0</summary>
+        private uint Reserved;
         /// <summary>reInitEncodeParams: [in]: Encoder session re-initialization parameters.
         /// If reInitEncodeParams.encodeConfig is NULL and
         /// reInitEncodeParams.presetGUID is the same as the preset
@@ -1605,6 +2427,9 @@ namespace Lennox.NvEncSharp
             get => (BitField1[0] & 2) != 0;
             set => BitField1[0] = value ? (byte)(BitField1[0] | 2) : (byte)(BitField1[0] & -3);
         }
+        /// <summary>reserved1</summary>
+        /// <summary>reserved2: [in]: Reserved and must be set to 0</summary>
+        private uint Reserved2;
     }
 
     /// <summary>NV_ENC_PRESET_CONFIG
@@ -1615,10 +2440,12 @@ namespace Lennox.NvEncSharp
     {
         /// <summary>version: [in]: Struct version. Must be set to ::NV_ENC_PRESET_CONFIG_VER.</summary>
         public uint Version;
+        /// <summary>reserved: [in]: Reserved and must be set to 0</summary>
+        private uint Reserved;
         /// <summary>presetCfg: [out]: preset config returned by the Nvidia Video Encoder interface.</summary>
         public NvEncConfig PresetCfg;
-        /// <summary>reserved1[255]: [in]: Reserved and must be set to 0</summary>
-        private fixed uint Reserved1[255];
+        /// <summary>reserved1[256]: [in]: Reserved and must be set to 0</summary>
+        private fixed uint Reserved1[256];
         /// <summary>reserved2[64]: [in]: Reserved and must be set to NULL</summary>
         #region Reserved2[64]
         private IntPtr Reserved20;
@@ -1794,20 +2621,22 @@ namespace Lennox.NvEncSharp
         public uint SliceModeData;
         /// <summary>ltrMarkFrameIdx: [in]: Specifies the long term referenceframe index to use for marking this frame as LTR.</summary>
         public uint LtrMarkFrameIdx;
-        /// <summary>ltrUseFrameBitmap: [in]: Specifies the the associated bitmap of LTR frame indices to use when encoding this frame.</summary>
+        /// <summary>ltrUseFrameBitmap: [in]: Specifies the associated bitmap of LTR frame indices to use when encoding this frame.</summary>
         public uint LtrUseFrameBitmap;
         /// <summary>ltrUsageMode: [in]: Not supported. Reserved for future use and must be set to 0.</summary>
         public uint LtrUsageMode;
-        /// <summary>forceIntraSliceCount: [in]: Specfies the number of slices to be forced to Intra in the current picture.
+        /// <summary>forceIntraSliceCount: [in]: Specifies the number of slices to be forced to Intra in the current picture.
         /// This option along with forceIntraSliceIdx[] array needs to be used with sliceMode = 3 only</summary>
         public uint ForceIntraSliceCount;
-        /// <summary>*forceIntraSliceIdx: [in]: Slice indices to be forced to intra in the current picture. Each slice index should be &lt;= num_slices_in_picture -1. Index starts from 0 for first slice.
+        /// <summary>*forceIntraSliceIdx: [in]: Slice indices to be forced to intra in the current picture. Each slice index should be <= num_slices_in_picture -1. Index starts from 0 for first slice.
         /// The number of entries in this array should be equal to forceIntraSliceCount</summary>
         public uint *forceIntraSliceIdx;
         /// <summary>h264ExtPicParams: [in]: Specifies the H264 extension config parameters using this config.</summary>
         public NvEncPicParamsH264Ext H264ExtPicParams;
-        /// <summary>reserved [210]: [in]: Reserved and must be set to 0.</summary>
-        private fixed uint Reserved [210];
+        /// <summary>timeCode: [in]: Specifies the clock timestamp sets used in picture timing SEI. Applicable only when NV_ENC_CONFIG_H264::enableTimeCode is set to 1.</summary>
+        public NvEncTimeCode TimeCode;
+        /// <summary>reserved [202]: [in]: Reserved and must be set to 0.</summary>
+        private fixed uint Reserved [202];
         /// <summary>reserved2[61]: [in]: Reserved and must be set to NULL.</summary>
         #region Reserved2[61]
         private IntPtr Reserved20;
@@ -1914,6 +2743,8 @@ namespace Lennox.NvEncSharp
             set => BitField1[0] = value ? (byte)(BitField1[0] | 8) : (byte)(BitField1[0] & -9);
         }
         /// <summary>reservedBitFields: [in]: Reserved bit fields and must be set to 0</summary>
+        /// <summary>reserved1: [in]: Reserved and must be set to 0.</summary>
+        private uint Reserved1;
         /// <summary>sliceTypeData: [in]: Array which specifies the slice type used to force intra slice for a particular slice. Currently supported only for NV_ENC_CONFIG_H264::sliceMode == 3.
         /// Client should allocate array of size sliceModeData where sliceModeData is specified in field of ::_NV_ENC_CONFIG_H264
         /// Array element with index n corresponds to nth slice. To force a particular slice to intra client should set corresponding array element to NV_ENC_SLICE_TYPE_I
@@ -1944,8 +2775,176 @@ namespace Lennox.NvEncSharp
         private uint Reserved;
         /// <summary>seiPayloadArray: [in]: Array of SEI payloads which will be inserted for this frame.</summary>
         public NvEncSeiPayload* SeiPayloadArray;
-        /// <summary>reserved2 [244]: [in]: Reserved and must be set to 0.</summary>
-        private fixed uint Reserved2 [244];
+        /// <summary>timeCode: [in]: Specifies the clock timestamp sets used in time code SEI. Applicable only when NV_ENC_CONFIG_HEVC::enableTimeCodeSEI is set to 1.</summary>
+        public NvEncTimeCode TimeCode;
+        /// <summary>reserved2[236]: [in]: Reserved and must be set to 0.</summary>
+        private fixed uint Reserved2[236];
+        /// <summary>reserved3[61]: [in]: Reserved and must be set to NULL.</summary>
+        #region Reserved3[61]
+        private IntPtr Reserved30;
+        private IntPtr Reserved31;
+        private IntPtr Reserved32;
+        private IntPtr Reserved33;
+        private IntPtr Reserved34;
+        private IntPtr Reserved35;
+        private IntPtr Reserved36;
+        private IntPtr Reserved37;
+        private IntPtr Reserved38;
+        private IntPtr Reserved39;
+        private IntPtr Reserved310;
+        private IntPtr Reserved311;
+        private IntPtr Reserved312;
+        private IntPtr Reserved313;
+        private IntPtr Reserved314;
+        private IntPtr Reserved315;
+        private IntPtr Reserved316;
+        private IntPtr Reserved317;
+        private IntPtr Reserved318;
+        private IntPtr Reserved319;
+        private IntPtr Reserved320;
+        private IntPtr Reserved321;
+        private IntPtr Reserved322;
+        private IntPtr Reserved323;
+        private IntPtr Reserved324;
+        private IntPtr Reserved325;
+        private IntPtr Reserved326;
+        private IntPtr Reserved327;
+        private IntPtr Reserved328;
+        private IntPtr Reserved329;
+        private IntPtr Reserved330;
+        private IntPtr Reserved331;
+        private IntPtr Reserved332;
+        private IntPtr Reserved333;
+        private IntPtr Reserved334;
+        private IntPtr Reserved335;
+        private IntPtr Reserved336;
+        private IntPtr Reserved337;
+        private IntPtr Reserved338;
+        private IntPtr Reserved339;
+        private IntPtr Reserved340;
+        private IntPtr Reserved341;
+        private IntPtr Reserved342;
+        private IntPtr Reserved343;
+        private IntPtr Reserved344;
+        private IntPtr Reserved345;
+        private IntPtr Reserved346;
+        private IntPtr Reserved347;
+        private IntPtr Reserved348;
+        private IntPtr Reserved349;
+        private IntPtr Reserved350;
+        private IntPtr Reserved351;
+        private IntPtr Reserved352;
+        private IntPtr Reserved353;
+        private IntPtr Reserved354;
+        private IntPtr Reserved355;
+        private IntPtr Reserved356;
+        private IntPtr Reserved357;
+        private IntPtr Reserved358;
+        private IntPtr Reserved359;
+        private IntPtr Reserved360;
+        #endregion Reserved3[61]
+    }
+
+    /// <summary>NV_ENC_PIC_PARAMS_AV1
+    /// struct _NV_ENC_PIC_PARAMS_AV1
+    /// AV1 specific enc pic params. sent on a per frame basis.</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct NvEncPicParamsAv1
+    {
+        /// <summary>displayPOCSyntax: [in]: Specifies the display POC syntax This is required to be set if client is handling the picture type decision.</summary>
+        public uint DisplayPOCSyntax;
+        /// <summary>refPicFlag: [in]: Set to 1 for a reference picture. This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1.</summary>
+        public uint RefPicFlag;
+        /// <summary>temporalId: [in]: Specifies the temporal id of the picture</summary>
+        public uint TemporalId;
+        /// <summary>forceIntraRefreshWithFrameCnt: [in]: Forces an intra refresh with duration equal to intraRefreshFrameCnt.
+        /// forceIntraRefreshWithFrameCnt cannot be used if B frames are used in the GOP structure specified</summary>
+        public uint ForceIntraRefreshWithFrameCnt;
+        internal fixed byte BitField1[1];
+        /// <summary>goldenFrameFlag: [in]: Encode frame as Golden Frame. This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1.</summary>
+        public bool GoldenFrameFlag {
+            get => (BitField1[0] & 1) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 1) : (byte)(BitField1[0] & -2);
+        }
+        /// <summary>arfFrameFlag: [in]: Encode frame as Alternate Reference Frame. This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1.</summary>
+        public bool ArfFrameFlag {
+            get => (BitField1[0] & 2) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 2) : (byte)(BitField1[0] & -3);
+        }
+        /// <summary>arf2FrameFlag: [in]: Encode frame as Alternate Reference 2 Frame. This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1.</summary>
+        public bool Arf2FrameFlag {
+            get => (BitField1[0] & 4) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 4) : (byte)(BitField1[0] & -5);
+        }
+        /// <summary>bwdFrameFlag: [in]: Encode frame as Backward Reference Frame. This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1.</summary>
+        public bool BwdFrameFlag {
+            get => (BitField1[0] & 8) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 8) : (byte)(BitField1[0] & -9);
+        }
+        /// <summary>overlayFrameFlag: [in]: Encode frame as overlay frame. A previously encoded frame with the same displayPOCSyntax value should be present in reference frame buffer.
+        /// This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1.</summary>
+        public bool OverlayFrameFlag {
+            get => (BitField1[0] & 16) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 16) : (byte)(BitField1[0] & -17);
+        }
+        /// <summary>showExistingFrameFlag: [in]: When ovelayFrameFlag is set to 1, this flag controls the value of the show_existing_frame syntax element associated with the overlay frame.
+        /// This flag is added to the interface as a placeholder. Its value is ignored for now and always assumed to be set to 1.
+        /// This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1.</summary>
+        public bool ShowExistingFrameFlag {
+            get => (BitField1[0] & 32) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 32) : (byte)(BitField1[0] & -33);
+        }
+        /// <summary>errorResilientModeFlag: [in]: encode frame independently from previously encoded frames</summary>
+        public bool ErrorResilientModeFlag {
+            get => (BitField1[0] & 64) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 64) : (byte)(BitField1[0] & -65);
+        }
+        /// <summary>tileConfigUpdate: [in]: Set to 1 if client wants to overwrite the default tile configuration with the tile parameters specified below
+        /// When forceIntraRefreshWithFrameCnt is set it will have priority over tileConfigUpdate setting</summary>
+        public bool TileConfigUpdate {
+            get => (BitField1[0] & 128) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 128) : (byte)(BitField1[0] & -129);
+        }
+        internal fixed byte BitField2[3];
+        /// <summary>enableCustomTileConfig: [in]: Set 1 to enable custom tile configuration: numTileColumns and numTileRows must have non zero values and tileWidths and tileHeights must point to a valid address</summary>
+        public bool EnableCustomTileConfig {
+            get => (BitField2[0] & 1) != 0;
+            set => BitField2[0] = value ? (byte)(BitField2[0] | 1) : (byte)(BitField2[0] & -2);
+        }
+        /// <summary>filmGrainParamsUpdate: [in]: Set to 1 if client wants to update previous film grain parameters: filmGrainParams must point to a valid address and encoder must have been configured with film grain enabled</summary>
+        public bool FilmGrainParamsUpdate {
+            get => (BitField2[0] & 2) != 0;
+            set => BitField2[0] = value ? (byte)(BitField2[0] | 2) : (byte)(BitField2[0] & -3);
+        }
+        /// <summary>reservedBitFields: [in]: Reserved bitfields and must be set to 0</summary>
+        /// <summary>numTileColumns: [in]: This parameter in conjunction with the flag enableCustomTileConfig and the array tileWidths[] specifies the way in which the picture is divided into tile columns.
+        /// When enableCustomTileConfig == 0, the picture will be uniformly divided into numTileColumns tile columns. If numTileColumns is not a power of 2,
+        /// it will be rounded down to the next power of 2 value. If numTileColumns == 0, the picture will be coded with the smallest number of vertical tiles as allowed by standard.
+        /// When enableCustomTileConfig == 1, numTileColumns must be > 0 and <= NV_MAX_TILE_COLS_AV1 and tileWidths must point to a valid array of numTileColumns entries.
+        /// Entry i specifies the width in 64x64 CTU unit of tile colum i. The sum of all the entries should be equal to the picture width in 64x64 CTU units.</summary>
+        public uint NumTileColumns;
+        /// <summary>numTileRows: [in]: This parameter in conjunction with the flag enableCustomTileConfig and the array tileHeights[] specifies the way in which the picture is divided into tiles rows
+        /// When enableCustomTileConfig == 0, the picture will be uniformly divided into numTileRows tile rows. If numTileRows is not a power of 2,
+        /// it will be rounded down to the next power of 2 value. If numTileRows == 0, the picture will be coded with the smallest number of horizontal tiles as allowed by standard.
+        /// When enableCustomTileConfig == 1, numTileRows must be > 0 and <= NV_MAX_TILE_ROWS_AV1 and tileHeights must point to a valid array of numTileRows entries.
+        /// Entry i specifies the height in 64x64 CTU unit of tile row i. The sum of all the entries should be equal to the picture hieght in 64x64 CTU units.</summary>
+        public uint NumTileRows;
+        /// <summary>reserved: [in]: Reserved and must be set to 0.</summary>
+        private uint Reserved;
+        /// <summary>*tileWidths: [in]: If enableCustomTileConfig == 1, tileWidths[i] specifies the width of tile column i in 64x64 CTU unit, with 0 <= i <= numTileColumns -1.</summary>
+        public uint *tileWidths;
+        /// <summary>*tileHeights: [in]: If enableCustomTileConfig == 1, tileHeights[i] specifies the height of tile row i in 64x64 CTU unit, with 0 <= i <= numTileRows -1.</summary>
+        public uint *tileHeights;
+        /// <summary>obuPayloadArrayCnt: [in]: Specifies the number of elements allocated in obuPayloadArray array.</summary>
+        public uint ObuPayloadArrayCnt;
+        /// <summary>reserved1: [in]: Reserved and must be set to 0.</summary>
+        private uint Reserved1;
+        /// <summary>obuPayloadArray: [in]: Array of OBU payloads which will be inserted for this frame.</summary>
+        public NvEncSeiPayload* ObuPayloadArray;
+        /// <summary>*filmGrainParams: [in]: If filmGrainParamsUpdate == 1, filmGrainParams must point to a valid NV_ENC_FILM_GRAIN_PARAMS_AV1 structure</summary>
+        public NvEncFilmGrainParamsAv1 *filmGrainParams;
+        /// <summary>reserved2[246]: [in]: Reserved and must be set to 0.</summary>
+        private fixed uint Reserved2[246];
         /// <summary>reserved3[61]: [in]: Reserved and must be set to NULL.</summary>
         #region Reserved3[61]
         private IntPtr Reserved30;
@@ -2020,17 +3019,20 @@ namespace Lennox.NvEncSharp
     {
         /// <summary>version: [in]: Struct version. Must be set to ::NV_ENC_PIC_PARAMS_VER.</summary>
         public uint Version;
-        /// <summary>inputWidth: [in]: Specifies the input buffer width</summary>
+        /// <summary>inputWidth: [in]: Specifies the input frame width</summary>
         public uint InputWidth;
-        /// <summary>inputHeight: [in]: Specifies the input buffer height</summary>
+        /// <summary>inputHeight: [in]: Specifies the input frame height</summary>
         public uint InputHeight;
         /// <summary>inputPitch: [in]: Specifies the input buffer pitch. If pitch value is not known, set this to inputWidth.</summary>
         public uint InputPitch;
-        /// <summary>encodePicFlags: [in]: Specifies bit-wise OR`ed encode pic flags. See ::NV_ENC_PIC_FLAGS enum.</summary>
+        /// <summary>encodePicFlags: [in]: Specifies bit-wise OR of encode picture flags. See ::NV_ENC_PIC_FLAGS enum.</summary>
         public uint EncodePicFlags;
-        /// <summary>frameIdx: [in]: Specifies the frame index associated with the input frame [optional].</summary>
+        /// <summary>frameIdx: [in]: Specifies the frame index associated with the input frame. It is necessary to pass this as monotonically increasing starting 0 when lookaheadLevel, UHQ Tuning Info
+        /// or encoding same frames multiple times without advancing encoder state feature are enabled</summary>
         public uint FrameIdx;
-        /// <summary>inputTimeStamp: [in]: Specifies presentation timestamp associated with the input picture.</summary>
+        /// <summary>inputTimeStamp: [in]: Specifies opaque data which is associated with the encoded frame, but not actually encoded in the output bitstream.
+        /// This opaque data can be used later to uniquely refer to the corresponding encoded frame. For example, it can be used
+        /// for identifying the frame to be invalidated in the reference picture buffer, if lost at the client.</summary>
         public ulong InputTimeStamp;
         /// <summary>inputDuration: [in]: Specifies duration of the input picture</summary>
         public ulong InputDuration;
@@ -2045,7 +3047,7 @@ namespace Lennox.NvEncSharp
         /// greater than the allocated buffer size for encoded bitstream, then the output buffer will have encoded bitstream data equal to buffer size. All CUDA operations on this buffer must use
         /// the default stream.</summary>
         public NvEncOutputPtr OutputBitstream;
-        /// <summary>completionEvent: [in]: Specifies an event to be signalled on completion of encoding of this Frame [only if operating in Asynchronous mode]. Each output buffer should be associated with a distinct event pointer.</summary>
+        /// <summary>completionEvent: [in]: Specifies an event to be signaled on completion of encoding of this Frame [only if operating in Asynchronous mode]. Each output buffer should be associated with a distinct event pointer.</summary>
         public IntPtr CompletionEvent;
         /// <summary>bufferFmt: [in]: Specifies the input buffer format.</summary>
         public NvEncBufferFormat BufferFmt;
@@ -2055,99 +3057,118 @@ namespace Lennox.NvEncSharp
         public NvEncPicType PictureType;
         /// <summary>codecPicParams: [in]: Specifies the codec specific per-picture encoding parameters.</summary>
         public NvEncCodecPicParams CodecPicParams;
-        /// <summary>meHintCountsPerBlock[2]: [in]: Specifies the number of hint candidates per block per direction for the current frame. meHintCountsPerBlock[0] is for L0 predictors and meHintCountsPerBlock[1] is for L1 predictors.
-        /// The candidate count in NV_ENC_PIC_PARAMS::meHintCountsPerBlock[lx] must never exceed NV_ENC_INITIALIZE_PARAMS::maxMEHintCountsPerBlock[lx] provided during encoder intialization.</summary>
+        /// <summary>meHintCountsPerBlock[2]: [in]: For H264 and Hevc, specifies the number of hint candidates per block per direction for the current frame. meHintCountsPerBlock[0] is for L0 predictors and meHintCountsPerBlock[1] is for L1 predictors.
+        /// The candidate count in NV_ENC_PIC_PARAMS::meHintCountsPerBlock[lx] must never exceed NV_ENC_INITIALIZE_PARAMS::maxMEHintCountsPerBlock[lx] provided during encoder initialization.</summary>
         public NvEncExternalMeHintCountsPerBlocktype MeHintCountsPerBlock0;
         public NvEncExternalMeHintCountsPerBlocktype MeHintCountsPerBlock1;
-        /// <summary>*meExternalHints: [in]: Specifies the pointer to ME external hints for the current frame. The size of ME hint buffer should be equal to number of macroblocks * the total number of candidates per macroblock.
+        /// <summary>*meExternalHints: [in]: For H264 and Hevc, Specifies the pointer to ME external hints for the current frame. The size of ME hint buffer should be equal to number of macroblocks * the total number of candidates per macroblock.
         /// The total number of candidates per MB per direction = 1*meHintCountsPerBlock[Lx].numCandsPerBlk16x16 + 2*meHintCountsPerBlock[Lx].numCandsPerBlk16x8 + 2*meHintCountsPerBlock[Lx].numCandsPerBlk8x8
         /// + 4*meHintCountsPerBlock[Lx].numCandsPerBlk8x8. For frames using bidirectional ME , the total number of candidates for single macroblock is sum of total number of candidates per MB for each direction (L0 and L1)</summary>
         public NvEncExternalMeHint *meExternalHints;
-        /// <summary>reserved1[6]: [in]: Reserved and must be set to 0</summary>
-        private fixed uint Reserved1[6];
-        /// <summary>reserved2[2]: [in]: Reserved and must be set to NULL</summary>
-        #region Reserved2[2]
-        private IntPtr Reserved20;
-        private IntPtr Reserved21;
-        #endregion Reserved2[2]
-        /// <summary>*qpDeltaMap: [in]: Specifies the pointer to signed byte array containing value per MB in raster scan order for the current picture, which will be interpreted depending on NV_ENC_RC_PARAMS::qpMapMode.
-        /// If NV_ENC_RC_PARAMS::qpMapMode is NV_ENC_QP_MAP_DELTA, qpDeltaMap specifies QP modifier per MB. This QP modifier will be applied on top of the QP chosen by rate control.
-        /// If NV_ENC_RC_PARAMS::qpMapMode is NV_ENC_QP_MAP_EMPHASIS, qpDeltaMap specifies Emphasis Level Map per MB. This level value along with QP chosen by rate control is used to
+        /// <summary>reserved2[7]: [in]: Reserved and must be set to 0</summary>
+        private fixed uint Reserved2[7];
+        /// <summary>reserved5[2]: [in]: Reserved and must be set to NULL</summary>
+        #region Reserved5[2]
+        private IntPtr Reserved50;
+        private IntPtr Reserved51;
+        #endregion Reserved5[2]
+        /// <summary>*qpDeltaMap: [in]: Specifies the pointer to signed byte array containing value per MB for H264, per CTB for HEVC and per SB for AV1 in raster scan order for the current picture, which will be interpreted depending on NV_ENC_RC_PARAMS::qpMapMode.
+        /// If NV_ENC_RC_PARAMS::qpMapMode is NV_ENC_QP_MAP_DELTA, qpDeltaMap specifies QP modifier per MB for H264, per CTB for HEVC and per SB for AV1. This QP modifier will be applied on top of the QP chosen by rate control.
+        /// If NV_ENC_RC_PARAMS::qpMapMode is NV_ENC_QP_MAP_EMPHASIS, qpDeltaMap specifies Emphasis Level Map per MB for H264. This level value along with QP chosen by rate control is used to
         /// compute the QP modifier, which in turn is applied on top of QP chosen by rate control.
         /// If NV_ENC_RC_PARAMS::qpMapMode is NV_ENC_QP_MAP_DISABLED, value in qpDeltaMap will be ignored.</summary>
         public byte *qpDeltaMap;
-        /// <summary>qpDeltaMapSize: [in]: Specifies the size in bytes of qpDeltaMap surface allocated by client and pointed to by NV_ENC_PIC_PARAMS::qpDeltaMap. Surface (array) should be picWidthInMbs * picHeightInMbs</summary>
+        /// <summary>qpDeltaMapSize: [in]: Specifies the size in bytes of qpDeltaMap surface allocated by client and pointed to by NV_ENC_PIC_PARAMS::qpDeltaMap. Surface (array) should be picWidthInMbs * picHeightInMbs for H264, picWidthInCtbs * picHeightInCtbs for HEVC and
+        /// picWidthInSbs * picHeightInSbs for AV1</summary>
         public uint QpDeltaMapSize;
         /// <summary>reservedBitFields: [in]: Reserved bitfields and must be set to 0</summary>
         private uint ReservedBitFields;
         /// <summary>meHintRefPicDist[2]: [in]: Specifies temporal distance for reference picture (NVENC_EXTERNAL_ME_HINT::refidx = 0) used during external ME with NV_ENC_INITALIZE_PARAMS::enablePTD = 1 . meHintRefPicDist[0] is for L0 hints and meHintRefPicDist[1] is for L1 hints.
         /// If not set, will internally infer distance of 1. Ignored for NV_ENC_INITALIZE_PARAMS::enablePTD = 0</summary>
         public fixed ushort MeHintRefPicDist[2];
-        /// <summary>reserved3[286]: [in]: Reserved and must be set to 0</summary>
-        private fixed uint Reserved3[286];
-        /// <summary>reserved4[60]: [in]: Reserved and must be set to NULL</summary>
-        #region Reserved4[60]
-        private IntPtr Reserved40;
-        private IntPtr Reserved41;
-        private IntPtr Reserved42;
-        private IntPtr Reserved43;
-        private IntPtr Reserved44;
-        private IntPtr Reserved45;
-        private IntPtr Reserved46;
-        private IntPtr Reserved47;
-        private IntPtr Reserved48;
-        private IntPtr Reserved49;
-        private IntPtr Reserved410;
-        private IntPtr Reserved411;
-        private IntPtr Reserved412;
-        private IntPtr Reserved413;
-        private IntPtr Reserved414;
-        private IntPtr Reserved415;
-        private IntPtr Reserved416;
-        private IntPtr Reserved417;
-        private IntPtr Reserved418;
-        private IntPtr Reserved419;
-        private IntPtr Reserved420;
-        private IntPtr Reserved421;
-        private IntPtr Reserved422;
-        private IntPtr Reserved423;
-        private IntPtr Reserved424;
-        private IntPtr Reserved425;
-        private IntPtr Reserved426;
-        private IntPtr Reserved427;
-        private IntPtr Reserved428;
-        private IntPtr Reserved429;
-        private IntPtr Reserved430;
-        private IntPtr Reserved431;
-        private IntPtr Reserved432;
-        private IntPtr Reserved433;
-        private IntPtr Reserved434;
-        private IntPtr Reserved435;
-        private IntPtr Reserved436;
-        private IntPtr Reserved437;
-        private IntPtr Reserved438;
-        private IntPtr Reserved439;
-        private IntPtr Reserved440;
-        private IntPtr Reserved441;
-        private IntPtr Reserved442;
-        private IntPtr Reserved443;
-        private IntPtr Reserved444;
-        private IntPtr Reserved445;
-        private IntPtr Reserved446;
-        private IntPtr Reserved447;
-        private IntPtr Reserved448;
-        private IntPtr Reserved449;
-        private IntPtr Reserved450;
-        private IntPtr Reserved451;
-        private IntPtr Reserved452;
-        private IntPtr Reserved453;
-        private IntPtr Reserved454;
-        private IntPtr Reserved455;
-        private IntPtr Reserved456;
-        private IntPtr Reserved457;
-        private IntPtr Reserved458;
-        private IntPtr Reserved459;
-        #endregion Reserved4[60]
+        /// <summary>reserved4: [in]: Reserved and must be set to 0</summary>
+        private uint Reserved4;
+        /// <summary>alphaBuffer: [in]: Specifies the input alpha buffer pointer. Client must use a pointer obtained from ::NvEncCreateInputBuffer() or ::NvEncMapInputResource() APIs.
+        /// Applicable only when encoding hevc with alpha layer is enabled.</summary>
+        public NvEncInputPtr AlphaBuffer;
+        /// <summary>*meExternalSbHints: [in]: For AV1,Specifies the pointer to ME external SB hints for the current frame. The size of ME hint buffer should be equal to meSbHintsCount.</summary>
+        public NvEncExternalMeSbHint *meExternalSbHints;
+        /// <summary>meSbHintsCount: [in]: For AV1, specifies the total number of external ME SB hint candidates for the frame
+        /// NV_ENC_PIC_PARAMS::meSbHintsCount must never exceed the total number of SBs in frame * the max number of candidates per SB provided during encoder initialization.
+        /// The max number of candidates per SB is maxMeHintCountsPerBlock[0].numCandsPerSb + maxMeHintCountsPerBlock[1].numCandsPerSb</summary>
+        public uint MeSbHintsCount;
+        /// <summary>stateBufferIdx: [in]: Specifies the buffer index in which the encoder state will be saved for current frame encode. It must be in the
+        /// range 0 to NV_ENC_INITIALIZE_PARAMS::numStateBuffers - 1.</summary>
+        public uint StateBufferIdx;
+        /// <summary>outputReconBuffer: [in]: Specifies the reconstructed frame buffer pointer to output reconstructed frame, if enabled by setting NV_ENC_INITIALIZE_PARAMS::enableReconFrameOutput.
+        /// Client must allocate buffers for writing the reconstructed frames and register them with the Nvidia Video Encoder Interface with NV_ENC_REGISTER_RESOURCE::bufferUsage
+        /// set to NV_ENC_OUTPUT_RECON.
+        /// Client must use the pointer obtained from ::NvEncMapInputResource() API and assign it to NV_ENC_PIC_PARAMS::outputReconBuffer.
+        /// Reconstructed output will be in NV_ENC_BUFFER_FORMAT_NV12 format when chromaFormatIDC is set to 1.
+        /// chromaFormatIDC = 3 is not supported.</summary>
+        public NvEncOutputPtr OutputReconBuffer;
+        /// <summary>reserved3[284]: [in]: Reserved and must be set to 0</summary>
+        private fixed uint Reserved3[284];
+        /// <summary>reserved6[57]: [in]: Reserved and must be set to NULL</summary>
+        #region Reserved6[57]
+        private IntPtr Reserved60;
+        private IntPtr Reserved61;
+        private IntPtr Reserved62;
+        private IntPtr Reserved63;
+        private IntPtr Reserved64;
+        private IntPtr Reserved65;
+        private IntPtr Reserved66;
+        private IntPtr Reserved67;
+        private IntPtr Reserved68;
+        private IntPtr Reserved69;
+        private IntPtr Reserved610;
+        private IntPtr Reserved611;
+        private IntPtr Reserved612;
+        private IntPtr Reserved613;
+        private IntPtr Reserved614;
+        private IntPtr Reserved615;
+        private IntPtr Reserved616;
+        private IntPtr Reserved617;
+        private IntPtr Reserved618;
+        private IntPtr Reserved619;
+        private IntPtr Reserved620;
+        private IntPtr Reserved621;
+        private IntPtr Reserved622;
+        private IntPtr Reserved623;
+        private IntPtr Reserved624;
+        private IntPtr Reserved625;
+        private IntPtr Reserved626;
+        private IntPtr Reserved627;
+        private IntPtr Reserved628;
+        private IntPtr Reserved629;
+        private IntPtr Reserved630;
+        private IntPtr Reserved631;
+        private IntPtr Reserved632;
+        private IntPtr Reserved633;
+        private IntPtr Reserved634;
+        private IntPtr Reserved635;
+        private IntPtr Reserved636;
+        private IntPtr Reserved637;
+        private IntPtr Reserved638;
+        private IntPtr Reserved639;
+        private IntPtr Reserved640;
+        private IntPtr Reserved641;
+        private IntPtr Reserved642;
+        private IntPtr Reserved643;
+        private IntPtr Reserved644;
+        private IntPtr Reserved645;
+        private IntPtr Reserved646;
+        private IntPtr Reserved647;
+        private IntPtr Reserved648;
+        private IntPtr Reserved649;
+        private IntPtr Reserved650;
+        private IntPtr Reserved651;
+        private IntPtr Reserved652;
+        private IntPtr Reserved653;
+        private IntPtr Reserved654;
+        private IntPtr Reserved655;
+        private IntPtr Reserved656;
+        #endregion Reserved6[57]
     }
 
     /// <summary>NV_ENC_MEONLY_PARAMS
@@ -2159,10 +3180,12 @@ namespace Lennox.NvEncSharp
     {
         /// <summary>version: [in]: Struct version. Must be set to NV_ENC_MEONLY_PARAMS_VER.</summary>
         public uint Version;
-        /// <summary>inputWidth: [in]: Specifies the input buffer width</summary>
+        /// <summary>inputWidth: [in]: Specifies the input frame width</summary>
         public uint InputWidth;
-        /// <summary>inputHeight: [in]: Specifies the input buffer height</summary>
+        /// <summary>inputHeight: [in]: Specifies the input frame height</summary>
         public uint InputHeight;
+        /// <summary>reserved: [in]: Reserved and must be set to 0</summary>
+        private uint Reserved;
         /// <summary>inputBuffer: [in]: Specifies the input buffer pointer. Client must use a pointer obtained from NvEncCreateInputBuffer() or NvEncMapInputResource() APIs.</summary>
         public NvEncInputPtr InputBuffer;
         /// <summary>referenceFrame: [in]: Specifies the reference frame pointer</summary>
@@ -2174,87 +3197,89 @@ namespace Lennox.NvEncSharp
         /// be equal to total number of macroblocks multiplied by size of NV_ENC_H264_MV_DATA struct. Client should use a pointer obtained from ::NvEncMapInputResource() API, when mapping this
         /// output buffer and assign it to NV_ENC_MEONLY_PARAMS::mvBuffer. All CUDA operations on this buffer must use the default stream.</summary>
         public NvEncOutputPtr MvBuffer;
+        /// <summary>reserved2: [in]: Reserved and must be set to 0</summary>
+        private uint Reserved2;
         /// <summary>bufferFmt: [in]: Specifies the input buffer format.</summary>
         public NvEncBufferFormat BufferFmt;
-        /// <summary>completionEvent: [in]: Specifies an event to be signalled on completion of motion estimation
+        /// <summary>completionEvent: [in]: Specifies an event to be signaled on completion of motion estimation
         /// of this Frame [only if operating in Asynchronous mode].
         /// Each output buffer should be associated with a distinct event pointer.</summary>
         public IntPtr CompletionEvent;
-        /// <summary>viewID: [in]: Specifies left,right viewID if NV_ENC_CONFIG_H264_MEONLY::bStereoEnable is set.
+        /// <summary>viewID: [in]: Specifies left or right viewID if NV_ENC_CONFIG_H264_MEONLY::bStereoEnable is set.
         /// viewID can be 0,1 if bStereoEnable is set, 0 otherwise.</summary>
         public uint ViewID;
         /// <summary>meHintCountsPerBlock[2]: [in]: Specifies the number of hint candidates per block for the current frame. meHintCountsPerBlock[0] is for L0 predictors.
-        /// The candidate count in NV_ENC_PIC_PARAMS::meHintCountsPerBlock[lx] must never exceed NV_ENC_INITIALIZE_PARAMS::maxMEHintCountsPerBlock[lx] provided during encoder intialization.</summary>
+        /// The candidate count in NV_ENC_PIC_PARAMS::meHintCountsPerBlock[lx] must never exceed NV_ENC_INITIALIZE_PARAMS::maxMEHintCountsPerBlock[lx] provided during encoder initialization.</summary>
         public NvEncExternalMeHintCountsPerBlocktype MeHintCountsPerBlock0;
         public NvEncExternalMeHintCountsPerBlocktype MeHintCountsPerBlock1;
         /// <summary>*meExternalHints: [in]: Specifies the pointer to ME external hints for the current frame. The size of ME hint buffer should be equal to number of macroblocks * the total number of candidates per macroblock.
         /// The total number of candidates per MB per direction = 1*meHintCountsPerBlock[Lx].numCandsPerBlk16x16 + 2*meHintCountsPerBlock[Lx].numCandsPerBlk16x8 + 2*meHintCountsPerBlock[Lx].numCandsPerBlk8x8
         /// + 4*meHintCountsPerBlock[Lx].numCandsPerBlk8x8. For frames using bidirectional ME , the total number of candidates for single macroblock is sum of total number of candidates per MB for each direction (L0 and L1)</summary>
         public NvEncExternalMeHint *meExternalHints;
-        /// <summary>reserved1[243]: [in]: Reserved and must be set to 0</summary>
-        private fixed uint Reserved1[243];
-        /// <summary>reserved2[59]: [in]: Reserved and must be set to NULL</summary>
-        #region Reserved2[59]
-        private IntPtr Reserved20;
-        private IntPtr Reserved21;
-        private IntPtr Reserved22;
-        private IntPtr Reserved23;
-        private IntPtr Reserved24;
-        private IntPtr Reserved25;
-        private IntPtr Reserved26;
-        private IntPtr Reserved27;
-        private IntPtr Reserved28;
-        private IntPtr Reserved29;
-        private IntPtr Reserved210;
-        private IntPtr Reserved211;
-        private IntPtr Reserved212;
-        private IntPtr Reserved213;
-        private IntPtr Reserved214;
-        private IntPtr Reserved215;
-        private IntPtr Reserved216;
-        private IntPtr Reserved217;
-        private IntPtr Reserved218;
-        private IntPtr Reserved219;
-        private IntPtr Reserved220;
-        private IntPtr Reserved221;
-        private IntPtr Reserved222;
-        private IntPtr Reserved223;
-        private IntPtr Reserved224;
-        private IntPtr Reserved225;
-        private IntPtr Reserved226;
-        private IntPtr Reserved227;
-        private IntPtr Reserved228;
-        private IntPtr Reserved229;
-        private IntPtr Reserved230;
-        private IntPtr Reserved231;
-        private IntPtr Reserved232;
-        private IntPtr Reserved233;
-        private IntPtr Reserved234;
-        private IntPtr Reserved235;
-        private IntPtr Reserved236;
-        private IntPtr Reserved237;
-        private IntPtr Reserved238;
-        private IntPtr Reserved239;
-        private IntPtr Reserved240;
-        private IntPtr Reserved241;
-        private IntPtr Reserved242;
-        private IntPtr Reserved243;
-        private IntPtr Reserved244;
-        private IntPtr Reserved245;
-        private IntPtr Reserved246;
-        private IntPtr Reserved247;
-        private IntPtr Reserved248;
-        private IntPtr Reserved249;
-        private IntPtr Reserved250;
-        private IntPtr Reserved251;
-        private IntPtr Reserved252;
-        private IntPtr Reserved253;
-        private IntPtr Reserved254;
-        private IntPtr Reserved255;
-        private IntPtr Reserved256;
-        private IntPtr Reserved257;
-        private IntPtr Reserved258;
-        #endregion Reserved2[59]
+        /// <summary>reserved1[241]: [in]: Reserved and must be set to 0</summary>
+        private fixed uint Reserved1[241];
+        /// <summary>reserved3[59]: [in]: Reserved and must be set to NULL</summary>
+        #region Reserved3[59]
+        private IntPtr Reserved30;
+        private IntPtr Reserved31;
+        private IntPtr Reserved32;
+        private IntPtr Reserved33;
+        private IntPtr Reserved34;
+        private IntPtr Reserved35;
+        private IntPtr Reserved36;
+        private IntPtr Reserved37;
+        private IntPtr Reserved38;
+        private IntPtr Reserved39;
+        private IntPtr Reserved310;
+        private IntPtr Reserved311;
+        private IntPtr Reserved312;
+        private IntPtr Reserved313;
+        private IntPtr Reserved314;
+        private IntPtr Reserved315;
+        private IntPtr Reserved316;
+        private IntPtr Reserved317;
+        private IntPtr Reserved318;
+        private IntPtr Reserved319;
+        private IntPtr Reserved320;
+        private IntPtr Reserved321;
+        private IntPtr Reserved322;
+        private IntPtr Reserved323;
+        private IntPtr Reserved324;
+        private IntPtr Reserved325;
+        private IntPtr Reserved326;
+        private IntPtr Reserved327;
+        private IntPtr Reserved328;
+        private IntPtr Reserved329;
+        private IntPtr Reserved330;
+        private IntPtr Reserved331;
+        private IntPtr Reserved332;
+        private IntPtr Reserved333;
+        private IntPtr Reserved334;
+        private IntPtr Reserved335;
+        private IntPtr Reserved336;
+        private IntPtr Reserved337;
+        private IntPtr Reserved338;
+        private IntPtr Reserved339;
+        private IntPtr Reserved340;
+        private IntPtr Reserved341;
+        private IntPtr Reserved342;
+        private IntPtr Reserved343;
+        private IntPtr Reserved344;
+        private IntPtr Reserved345;
+        private IntPtr Reserved346;
+        private IntPtr Reserved347;
+        private IntPtr Reserved348;
+        private IntPtr Reserved349;
+        private IntPtr Reserved350;
+        private IntPtr Reserved351;
+        private IntPtr Reserved352;
+        private IntPtr Reserved353;
+        private IntPtr Reserved354;
+        private IntPtr Reserved355;
+        private IntPtr Reserved356;
+        private IntPtr Reserved357;
+        private IntPtr Reserved358;
+        #endregion Reserved3[59]
     }
 
     /// <summary>NV_ENC_LOCK_BITSTREAM
@@ -2284,15 +3309,17 @@ namespace Lennox.NvEncSharp
         /// <summary>reservedBitFields: [in]: Reserved bit fields and must be set to 0</summary>
         /// <summary>outputBitstream: [in]: Pointer to the bitstream buffer being locked.</summary>
         public IntPtr OutputBitstream;
-        /// <summary>sliceOffsets: [in,out]: Array which receives the slice offsets. This is not supported if NV_ENC_CONFIG_H264::sliceMode is 1 on Kepler GPUs. Array size must be equal to size of frame in MBs.</summary>
+        /// <summary>sliceOffsets: [in, out]: Array which receives the slice (H264/HEVC) or tile (AV1) offsets. This is not supported if NV_ENC_CONFIG_H264::sliceMode is 1 on Kepler GPUs. Array size must be equal to size of frame in MBs.</summary>
         public uint* SliceOffsets;
         /// <summary>frameIdx: [out]: Frame no. for which the bitstream is being retrieved.</summary>
         public uint FrameIdx;
         /// <summary>hwEncodeStatus: [out]: The NvEncodeAPI interface status for the locked picture.</summary>
         public uint HwEncodeStatus;
-        /// <summary>numSlices: [out]: Number of slices in the encoded picture. Will be reported only if NV_ENC_INITIALIZE_PARAMS::reportSliceOffsets set to 1.</summary>
+        /// <summary>numSlices: [out]: Number of slices (H264/HEVC) or tiles (AV1) in the encoded picture. Will be reported only if NV_ENC_INITIALIZE_PARAMS::reportSliceOffsets set to 1.</summary>
         public uint NumSlices;
-        /// <summary>bitstreamSizeInBytes: [out]: Actual number of bytes generated and copied to the memory pointed by bitstreamBufferPtr.</summary>
+        /// <summary>bitstreamSizeInBytes: [out]: Actual number of bytes generated and copied to the memory pointed by bitstreamBufferPtr.
+        /// When HEVC alpha layer encoding is enabled, this field reports the total encoded size in bytes i.e it is the encoded size of the base plus the alpha layer.
+        /// For AV1 when enablePTD is set, this field reports the total encoded size in bytes of all the encoded frames packed into the current output surface i.e. show frame plus all preceding no-show frames</summary>
         public uint BitstreamSizeInBytes;
         /// <summary>outputTimeStamp: [out]: Presentation timestamp associated with the encoded output.</summary>
         public ulong OutputTimeStamp;
@@ -2314,20 +3341,30 @@ namespace Lennox.NvEncSharp
         public uint LtrFrameIdx;
         /// <summary>ltrFrameBitmap: [out]: Bitmap of LTR frames indices which were used for encoding this frame. Value of 0 if no LTR frames were used.</summary>
         public uint LtrFrameBitmap;
-        /// <summary>reserved[13]: [in]: Reserved and must be set to 0</summary>
-        private fixed uint Reserved[13];
-        /// <summary>intraMBCount: [out]: For H264, Number of Intra MBs in the encoded frame. For HEVC, Number of Intra CTBs in the encoded frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1.</summary>
+        /// <summary>temporalId: [out]: TemporalId value of the frame when using temporalSVC encoding</summary>
+        public uint TemporalId;
+        /// <summary>intraMBCount: [out]: For H264, Number of Intra MBs in the encoded frame. For HEVC, Number of Intra CTBs in the encoded frame. For AV1, Number of Intra SBs in the encoded show frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1.</summary>
         public uint IntraMBCount;
-        /// <summary>interMBCount: [out]: For H264, Number of Inter MBs in the encoded frame, includes skip MBs. For HEVC, Number of Inter CTBs in the encoded frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1.</summary>
+        /// <summary>interMBCount: [out]: For H264, Number of Inter MBs in the encoded frame, includes skip MBs. For HEVC, Number of Inter CTBs in the encoded frame. For AV1, Number of Inter SBs in the encoded show frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1.</summary>
         public uint InterMBCount;
         /// <summary>averageMVX: [out]: Average Motion Vector in X direction for the encoded frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1.</summary>
         public int AverageMVX;
         /// <summary>averageMVY: [out]: Average Motion Vector in y direction for the encoded frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1.</summary>
         public int AverageMVY;
+        /// <summary>alphaLayerSizeInBytes: [out]: Number of bytes generated for the alpha layer in the encoded output. Applicable only when HEVC with alpha encoding is enabled.</summary>
+        public uint AlphaLayerSizeInBytes;
+        /// <summary>outputStatsPtrSize: [in]: Size of the buffer pointed by NV_ENC_LOCK_BITSTREAM::outputStatsPtr.</summary>
+        public uint OutputStatsPtrSize;
+        /// <summary>reserved: [in]: Reserved and must be set to 0</summary>
+        private uint Reserved;
+        /// <summary>outputStatsPtr: [in, out]: Buffer which receives the encoded frame output stats, if NV_ENC_INITIALIZE_PARAMS::enableOutputStats is set to 1.</summary>
+        public IntPtr OutputStatsPtr;
+        /// <summary>frameIdxDisplay: [out]: Frame index in display order</summary>
+        public uint FrameIdxDisplay;
         /// <summary>reserved1[219]: [in]: Reserved and must be set to 0</summary>
         private fixed uint Reserved1[219];
-        /// <summary>reserved2[64]: [in]: Reserved and must be set to NULL</summary>
-        #region Reserved2[64]
+        /// <summary>reserved2[63]: [in]: Reserved and must be set to NULL</summary>
+        #region Reserved2[63]
         private IntPtr Reserved20;
         private IntPtr Reserved21;
         private IntPtr Reserved22;
@@ -2391,15 +3428,9 @@ namespace Lennox.NvEncSharp
         private IntPtr Reserved260;
         private IntPtr Reserved261;
         private IntPtr Reserved262;
-        private IntPtr Reserved263;
-        #endregion Reserved2[64]
-
-        public UnmanagedMemoryStream CreateUnmanagedMemoryStream()
-        {
-            return new UnmanagedMemoryStream(
-                (byte*) BitstreamBufferPtr,
-                BitstreamSizeInBytes);
-        }
+        #endregion Reserved2[63]
+        /// <summary>reservedInternal[8]: [in]: Reserved and must be set to 0</summary>
+        private fixed uint ReservedInternal[8];
     }
 
     /// <summary>NV_ENC_LOCK_INPUT_BUFFER
@@ -2595,6 +3626,116 @@ namespace Lennox.NvEncSharp
         public uint Target;
     }
 
+    /// <summary>NV_ENC_FENCE_POINT_D3D12
+    /// struct NV_ENC_FENCE_POINT_D3D12
+    /// Fence and fence value for synchronization.</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct NvEncFencePointD3d12
+    {
+        /// <summary>version: [in]: Struct version. Must be set to ::NV_ENC_FENCE_POINT_D3D12_VER.</summary>
+        public uint Version;
+        /// <summary>reserved: [in]: Reserved and must be set to 0.</summary>
+        private uint Reserved;
+        /// <summary>pFence: [in]: Pointer to ID3D12Fence. This fence object is used for synchronization.</summary>
+        public IntPtr PFence;
+        /// <summary>waitValue: [in]: Fence value to reach or exceed before the GPU operation.</summary>
+        public ulong WaitValue;
+        /// <summary>signalValue: [in]: Fence value to set the fence to, after the GPU operation.</summary>
+        public ulong SignalValue;
+        internal fixed byte BitField1[4];
+        /// <summary>bWait: [in]: Wait on 'waitValue' if bWait is set to 1, before starting GPU operation.</summary>
+        public bool BWait {
+            get => (BitField1[0] & 1) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 1) : (byte)(BitField1[0] & -2);
+        }
+        /// <summary>bSignal: [in]: Signal on 'signalValue' if bSignal is set to 1, after GPU operation is complete.</summary>
+        public bool BSignal {
+            get => (BitField1[0] & 2) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 2) : (byte)(BitField1[0] & -3);
+        }
+        /// <summary>reservedBitField: [in]: Reserved and must be set to 0.</summary>
+        /// <summary>reserved1[7]: [in]: Reserved and must be set to 0.</summary>
+        private fixed uint Reserved1[7];
+    }
+
+    /// <summary>NV_ENC_INPUT_RESOURCE_D3D12
+    /// struct _NV_ENC_INPUT_RESOURCE_D3D12
+    /// NV_ENC_PIC_PARAMS::inputBuffer and NV_ENC_PIC_PARAMS::alphaBuffer must be a pointer to a struct of this type,
+    /// when D3D12 interface is used</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct NvEncInputResourceD3d12
+    {
+        /// <summary>version: [in]: Struct version. Must be set to ::NV_ENC_INPUT_RESOURCE_D3D12_VER.</summary>
+        public uint Version;
+        /// <summary>reserved: [in]: Reserved and must be set to 0.</summary>
+        private uint Reserved;
+        /// <summary>pInputBuffer: [in]: Specifies the input surface pointer. Client must use a pointer obtained from NvEncMapInputResource() in NV_ENC_MAP_INPUT_RESOURCE::mappedResource
+        /// when mapping the input surface.</summary>
+        public NvEncInputPtr PInputBuffer;
+        /// <summary>inputFencePoint: [in]: Specifies the fence and corresponding fence values to do GPU wait and signal.</summary>
+        public NvEncFencePointD3d12 InputFencePoint;
+        /// <summary>reserved1[16]: [in]: Reserved and must be set to 0.</summary>
+        private fixed uint Reserved1[16];
+        /// <summary>reserved2[16]: [in]: Reserved and must be set to NULL.</summary>
+        #region Reserved2[16]
+        private IntPtr Reserved20;
+        private IntPtr Reserved21;
+        private IntPtr Reserved22;
+        private IntPtr Reserved23;
+        private IntPtr Reserved24;
+        private IntPtr Reserved25;
+        private IntPtr Reserved26;
+        private IntPtr Reserved27;
+        private IntPtr Reserved28;
+        private IntPtr Reserved29;
+        private IntPtr Reserved210;
+        private IntPtr Reserved211;
+        private IntPtr Reserved212;
+        private IntPtr Reserved213;
+        private IntPtr Reserved214;
+        private IntPtr Reserved215;
+        #endregion Reserved2[16]
+    }
+
+    /// <summary>NV_ENC_OUTPUT_RESOURCE_D3D12
+    /// struct _NV_ENC_OUTPUT_RESOURCE_D3D12
+    /// NV_ENC_PIC_PARAMS::outputBitstream and NV_ENC_LOCK_BITSTREAM::outputBitstream must be a pointer to a struct of this type,
+    /// when D3D12 interface is used</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct NvEncOutputResourceD3d12
+    {
+        /// <summary>version: [in]: Struct version. Must be set to ::NV_ENC_OUTPUT_RESOURCE_D3D12_VER.</summary>
+        public uint Version;
+        /// <summary>reserved: [in]: Reserved and must be set to 0.</summary>
+        private uint Reserved;
+        /// <summary>pOutputBuffer: [in]: Specifies the output buffer pointer. Client must use a pointer obtained from NvEncMapInputResource() in NV_ENC_MAP_INPUT_RESOURCE::mappedResource
+        /// when mapping output bitstream buffer</summary>
+        public NvEncInputPtr POutputBuffer;
+        /// <summary>outputFencePoint: [in]: Specifies the fence and corresponding fence values to do GPU wait and signal.</summary>
+        public NvEncFencePointD3d12 OutputFencePoint;
+        /// <summary>reserved1[16]: [in]: Reserved and must be set to 0.</summary>
+        private fixed uint Reserved1[16];
+        /// <summary>reserved2[16]: [in]: Reserved and must be set to NULL.</summary>
+        #region Reserved2[16]
+        private IntPtr Reserved20;
+        private IntPtr Reserved21;
+        private IntPtr Reserved22;
+        private IntPtr Reserved23;
+        private IntPtr Reserved24;
+        private IntPtr Reserved25;
+        private IntPtr Reserved26;
+        private IntPtr Reserved27;
+        private IntPtr Reserved28;
+        private IntPtr Reserved29;
+        private IntPtr Reserved210;
+        private IntPtr Reserved211;
+        private IntPtr Reserved212;
+        private IntPtr Reserved213;
+        private IntPtr Reserved214;
+        private IntPtr Reserved215;
+        #endregion Reserved2[16]
+    }
+
     /// <summary>NV_ENC_REGISTER_RESOURCE
     /// struct _NV_ENC_REGISTER_RESOURCE
     /// Register a resource for future use with the Nvidia Video Encoder Interface.</summary>
@@ -2609,11 +3750,11 @@ namespace Lennox.NvEncSharp
         /// ::NV_ENC_INPUT_RESOURCE_TYPE_CUDADEVICEPTR,
         /// ::NV_ENC_INPUT_RESOURCE_TYPE_OPENGL_TEX</summary>
         public NvEncInputResourceType ResourceType;
-        /// <summary>width: [in]: Input buffer Width.</summary>
+        /// <summary>width: [in]: Input frame width.</summary>
         public uint Width;
-        /// <summary>height: [in]: Input buffer Height.</summary>
+        /// <summary>height: [in]: Input frame height.</summary>
         public uint Height;
-        /// <summary>pitch: [in]: Input buffer Pitch.
+        /// <summary>pitch: [in]: Input buffer pitch.
         /// For ::NV_ENC_INPUT_RESOURCE_TYPE_DIRECTX resources, set this to 0.
         /// For ::NV_ENC_INPUT_RESOURCE_TYPE_CUDADEVICEPTR resources, set this to
         /// the pitch as obtained from cuMemAllocPitch(), or to the width in
@@ -2636,10 +3777,23 @@ namespace Lennox.NvEncSharp
         public NvEncBufferFormat BufferFormat;
         /// <summary>bufferUsage: [in]: Usage of resource to be registered.</summary>
         public NvEncBufferUsage BufferUsage;
-        /// <summary>reserved1[247]: [in]: Reserved and must be set to 0.</summary>
-        private fixed uint Reserved1[247];
-        /// <summary>reserved2[62]: [in]: Reserved and must be set to NULL.</summary>
-        #region Reserved2[62]
+        /// <summary>pInputFencePoint: [in]: Specifies the input fence and corresponding fence values to do GPU wait and signal.
+        /// To be used only when NV_ENC_REGISTER_RESOURCE::resourceToRegister represents D3D12 surface and
+        /// NV_ENC_BUFFER_USAGE::bufferUsage is NV_ENC_INPUT_IMAGE.
+        /// The fence NV_ENC_FENCE_POINT_D3D12::pFence and NV_ENC_FENCE_POINT_D3D12::waitValue will be used to do GPU wait
+        /// before starting GPU operation, if NV_ENC_FENCE_POINT_D3D12::bWait is set.
+        /// The fence NV_ENC_FENCE_POINT_D3D12::pFence and NV_ENC_FENCE_POINT_D3D12::signalValue will be used to do GPU signal
+        /// when GPU operation finishes, if NV_ENC_FENCE_POINT_D3D12::bSignal is set.</summary>
+        public NvEncFencePointD3d12* PInputFencePoint;
+        /// <summary>chromaOffset[2]: [out]: Chroma offset for the reconstructed output buffer when NV_ENC_BUFFER_USAGE::bufferUsage is set
+        /// to NV_ENC_OUTPUT_RECON and D3D11 interface is used.
+        /// When chroma components are interleaved, 'chromaOffset[0]' will contain chroma offset.
+        /// chromaOffset[1] is reserved for future use.</summary>
+        public fixed uint ChromaOffset[2];
+        /// <summary>reserved1[246]: [in]: Reserved and must be set to 0.</summary>
+        private fixed uint Reserved1[246];
+        /// <summary>reserved2[61]: [in]: Reserved and must be set to NULL.</summary>
+        #region Reserved2[61]
         private IntPtr Reserved20;
         private IntPtr Reserved21;
         private IntPtr Reserved22;
@@ -2701,8 +3855,7 @@ namespace Lennox.NvEncSharp
         private IntPtr Reserved258;
         private IntPtr Reserved259;
         private IntPtr Reserved260;
-        private IntPtr Reserved261;
-        #endregion Reserved2[62]
+        #endregion Reserved2[61]
     }
 
     /// <summary>NV_ENC_STAT
@@ -2715,7 +3868,7 @@ namespace Lennox.NvEncSharp
         public uint Version;
         /// <summary>reserved: [in]: Reserved and must be set to 0</summary>
         private uint Reserved;
-        /// <summary>outputBitStream: [out]: Specifies the pointer to output bitstream.</summary>
+        /// <summary>outputBitStream: [in]: Specifies the pointer to output bitstream.</summary>
         public NvEncOutputPtr OutputBitStream;
         /// <summary>bitStreamSize: [out]: Size of generated bitstream in bytes.</summary>
         public uint BitStreamSize;
@@ -2727,8 +3880,27 @@ namespace Lennox.NvEncSharp
         public fixed uint SliceOffsets[16];
         /// <summary>picIdx: [out]: Picture number</summary>
         public uint PicIdx;
-        /// <summary>reserved1[233]: [in]: Reserved and must be set to 0</summary>
-        private fixed uint Reserved1[233];
+        /// <summary>frameAvgQP: [out]: Average QP of the frame.</summary>
+        public uint FrameAvgQP;
+        internal fixed byte BitField1[4];
+        /// <summary>ltrFrame: [out]: Flag indicating this frame is marked as LTR frame</summary>
+        public bool LtrFrame {
+            get => (BitField1[0] & 1) != 0;
+            set => BitField1[0] = value ? (byte)(BitField1[0] | 1) : (byte)(BitField1[0] & -2);
+        }
+        /// <summary>reservedBitFields: [in]: Reserved bit fields and must be set to 0</summary>
+        /// <summary>ltrFrameIdx: [out]: Frame index associated with this LTR frame.</summary>
+        public uint LtrFrameIdx;
+        /// <summary>intraMBCount: [out]: For H264, Number of Intra MBs in the encoded frame. For HEVC, Number of Intra CTBs in the encoded frame.</summary>
+        public uint IntraMBCount;
+        /// <summary>interMBCount: [out]: For H264, Number of Inter MBs in the encoded frame, includes skip MBs. For HEVC, Number of Inter CTBs in the encoded frame.</summary>
+        public uint InterMBCount;
+        /// <summary>averageMVX: [out]: Average Motion Vector in X direction for the encoded frame.</summary>
+        public int AverageMVX;
+        /// <summary>averageMVY: [out]: Average Motion Vector in y direction for the encoded frame.</summary>
+        public int AverageMVY;
+        /// <summary>reserved1[227]: [in]: Reserved and must be set to 0</summary>
+        private fixed uint Reserved1[227];
         /// <summary>reserved2[64]: [in]: Reserved and must be set to NULL</summary>
         #region Reserved2[64]
         private IntPtr Reserved20;
@@ -2806,15 +3978,16 @@ namespace Lennox.NvEncSharp
     {
         /// <summary>version: [in]: Struct version. Must be set to ::NV_ENC_INITIALIZE_PARAMS_VER.</summary>
         public uint Version;
-        /// <summary>inBufferSize: [in]: Specifies the size of the spsppsBuffer provied by the client</summary>
+        /// <summary>inBufferSize: [in]: Specifies the size of the spsppsBuffer provided by the client</summary>
         public uint InBufferSize;
         /// <summary>spsId: [in]: Specifies the SPS id to be used in sequence header. Default value is 0.</summary>
         public uint SpsId;
         /// <summary>ppsId: [in]: Specifies the PPS id to be used in picture header. Default value is 0.</summary>
         public uint PpsId;
-        /// <summary>spsppsBuffer: [in]: Specifies bitstream header pointer of size NV_ENC_SEQUENCE_PARAM_PAYLOAD::inBufferSize. It is the client's responsibility to manage this memory.</summary>
+        /// <summary>spsppsBuffer: [in]: Specifies bitstream header pointer of size NV_ENC_SEQUENCE_PARAM_PAYLOAD::inBufferSize.
+        /// It is the client's responsibility to manage this memory.</summary>
         public IntPtr SpsppsBuffer;
-        /// <summary>outSPSPPSPayloadSize: [out]: Size of the sequence and picture header in bytes written by the NvEncodeAPI interface to the SPSPPSBuffer.</summary>
+        /// <summary>outSPSPPSPayloadSize: [out]: Size of the sequence and picture header in bytes.</summary>
         public uint* OutSPSPPSPayloadSize;
         /// <summary>reserved [250]: [in]: Reserved and must be set to 0</summary>
         private fixed uint Reserved [250];
@@ -2897,8 +4070,8 @@ namespace Lennox.NvEncSharp
         private uint Reserved;
         /// <summary>completionEvent: [in]: Handle to event to be registered/unregistered with the NvEncodeAPI interface.</summary>
         public IntPtr CompletionEvent;
-        /// <summary>reserved1[253]: [in]: Reserved and must be set to 0</summary>
-        private fixed uint Reserved1[253];
+        /// <summary>reserved1[254]: [in]: Reserved and must be set to 0</summary>
+        private fixed uint Reserved1[254];
         /// <summary>reserved2[64]: [in]: Reserved and must be set to NULL</summary>
         #region Reserved2[64]
         private IntPtr Reserved20;


### PR DESCRIPTION
Hi,

I was facing some problems with video encoding with some more recent nvidia drivers. I found a post on the [nvidia forum](https://forums.developer.nvidia.com/t/drivers-591-44-broke-nvenc-getencodepresetconfig-no-longer-works/353613/7) describing the problem and it seems that the function GetEncodePresetConfig is not working correctly any more and is deprecated. Instead, one should use GetEncodePresetConfigEx which was added in API V 12, so I updated the API to V 12.2. Also, the preset-GUIDs and preset-names changed.

I used your test methods to generate the enum and struct files and reworked the GUIDs and the function list. However, I only added the GetEncodePresetConfigEx function pointer even though V12 added some more functions. I got the ScreenCapture example to work again, but I didn't test the whole API, so be aware.

Opening the pull request since the old API will eventually will be obsolete, so it might be interesting for you.

Best regards,
Christian